### PR TITLE
fix: restore invites page build dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,9 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.14",
         "typescript": "^5.5.4",
         "vite": "^5.4.8"
       }
@@ -443,6 +446,44 @@
       "version": "0.4.0",
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.11.0",
       "license": "MIT",
@@ -687,6 +728,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -901,6 +956,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -908,6 +973,8 @@
     },
     "node_modules/postcss": {
       "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -932,6 +999,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -1075,6 +1149,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
+      "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,19 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "i18next": "^23.11.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.2",
-    "i18next": "^23.11.5",
-    "react-i18next": "^14.1.2"
+    "react-i18next": "^14.1.2",
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.14",
     "typescript": "^5.5.4",
     "vite": "^5.4.8"
   }

--- a/frontend/src/pages/Invites.tsx
+++ b/frontend/src/pages/Invites.tsx
@@ -1,20 +1,267 @@
-// ... остальной код страницы без изменений
-{result && (
-  <div style={{ marginTop: 16 }}>
-    <h3>Результат</h3>
-    <pre style={{ background: '#111', color: '#eee', padding: 12, borderRadius: 8 }}>
-{JSON.stringify(result, null, 2)}
-    </pre>
-    {'code' in result && (
-      <div style={{ marginTop: 8 }}>
-        <div>Ссылка для регистрации:</div>
-        <code>
-          {`${window.location.origin}/register/${result.code}`}
-        </code>
-        <div style={{ marginTop: 6, fontSize: 12, opacity: 0.8 }}>
-          Отправьте её пользователю. Он задаст пароль и затем войдёт.
+import { FormEvent, useMemo, useState } from 'react'
+import { http } from '../shared/http'
+
+/**
+ * InviteRecord описывает ответ API по созданию инвайта.
+ * Приводим имена полей к camelCase, чтобы удобнее использовать в React.
+ */
+type InviteRecord = {
+  code: string
+  email: string
+  role: 'admin' | 'office' | 'supervisor' | 'promoter'
+  fullName?: string | null
+  expiresAt: string
+}
+
+const roleOptions: Array<{ value: InviteRecord['role']; label: string; hint: string }> = [
+  { value: 'promoter', label: 'Промоутер', hint: 'Доступ к ежедневным отчётам и бонусам' },
+  { value: 'supervisor', label: 'Супервизор', hint: 'Региональная аналитика и коммуникации' },
+  { value: 'office', label: 'Офис', hint: 'Планирование, бонусная сетка, сообщения' },
+  { value: 'admin', label: 'Администратор', hint: 'Полный доступ (использовать осторожно)' },
+]
+
+const expiryOptions: Array<{ hours: number; label: string }> = [
+  { hours: 24, label: '24 часа' },
+  { hours: 72, label: '3 дня' },
+  { hours: 168, label: '7 дней' },
+  { hours: 336, label: '14 дней' },
+]
+
+/**
+ * Возвращает ссылку для регистрации по инвайту.
+ */
+function buildInviteUrl(code: string): string {
+  if (typeof window === 'undefined') return `/register/${code}`
+  const origin = window.location.origin.replace(/\/$/, '')
+  return `${origin}/register/${code}`
+}
+
+/**
+ * Приводим ISO-дату к локальному формату без лишних деталей.
+ */
+function formatExpiresAt(value: string): string {
+  const dt = new Date(value)
+  if (Number.isNaN(dt.getTime())) return value
+  return dt.toLocaleString('ru-RU', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/**
+ * Страница управления инвайтами (admin/office).
+ * Позволяет выпускать ссылки для регистрации и отслеживать последние созданные приглашения.
+ */
+export default function InvitesPage() {
+  const [email, setEmail] = useState('')
+  const [fullName, setFullName] = useState('')
+  const [role, setRole] = useState<InviteRecord['role']>('promoter')
+  const [expiresHours, setExpiresHours] = useState<number>(72)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [recent, setRecent] = useState<InviteRecord | null>(null)
+  const [history, setHistory] = useState<InviteRecord[]>([])
+
+  const inviteUrl = useMemo(() => (recent ? buildInviteUrl(recent.code) : ''), [recent])
+
+  async function handleSubmit(evt: FormEvent<HTMLFormElement>) {
+    evt.preventDefault()
+    setError(null)
+
+    if (!email.trim()) {
+      setError('Укажите email получателя')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const payload = {
+        email: email.trim(),
+        role,
+        full_name: fullName.trim() || undefined,
+        expires_hours: expiresHours,
+      }
+      const { data } = await http.post('/api/v1/auth/invites', payload)
+      const normalized: InviteRecord = {
+        code: data.code,
+        email: data.email,
+        role: data.role,
+        fullName: data.full_name ?? null,
+        expiresAt: data.expires_at,
+      }
+      setRecent(normalized)
+      setHistory((prev) => [normalized, ...prev].slice(0, 10))
+      setEmail('')
+      setFullName('')
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail || err?.message || 'Не удалось создать инвайт'
+      setError(detail)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function copyInvite() {
+    if (!inviteUrl) return
+    try {
+      await navigator.clipboard.writeText(inviteUrl)
+      alert('Ссылка скопирована в буфер обмена')
+    } catch (err) {
+      console.warn('Clipboard error', err)
+      alert(inviteUrl)
+    }
+  }
+
+  return (
+    <div style={{ padding: 24, maxWidth: 720, margin: '0 auto' }}>
+      <h1 style={{ fontSize: 24, marginBottom: 12 }}>Инвайты пользователей</h1>
+      <p style={{ marginBottom: 24, color: '#4b5563' }}>
+        Выпускайте приглашения для сотрудников. Получатель перейдёт по ссылке, задаст пароль и войдёт в систему.
+      </p>
+
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 16, background: '#111827', color: '#f9fafb', padding: 20, borderRadius: 12 }}>
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label htmlFor="invite-email">Email сотрудника</label>
+          <input
+            id="invite-email"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="user@oppo.kz"
+            style={{ padding: '10px 12px', borderRadius: 8, border: '1px solid #374151', color: '#111827' }}
+          />
         </div>
-      </div>
-    )}
-  </div>
-)}
+
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label htmlFor="invite-name">ФИО (опционально)</label>
+          <input
+            id="invite-name"
+            type="text"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            placeholder="Иванова Алия"
+            style={{ padding: '10px 12px', borderRadius: 8, border: '1px solid #374151', color: '#111827' }}
+          />
+        </div>
+
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label htmlFor="invite-role">Роль</label>
+          <select
+            id="invite-role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as InviteRecord['role'])}
+            style={{ padding: '10px 12px', borderRadius: 8, border: '1px solid #374151', color: '#111827' }}
+          >
+            {roleOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <small style={{ color: '#d1d5db' }}>{roleOptions.find((opt) => opt.value === role)?.hint}</small>
+        </div>
+
+        <div style={{ display: 'grid', gap: 6 }}>
+          <label htmlFor="invite-expiry">Срок действия</label>
+          <select
+            id="invite-expiry"
+            value={expiresHours}
+            onChange={(e) => setExpiresHours(Number(e.target.value))}
+            style={{ padding: '10px 12px', borderRadius: 8, border: '1px solid #374151', color: '#111827' }}
+          >
+            {expiryOptions.map((opt) => (
+              <option key={opt.hours} value={opt.hours}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <small style={{ color: '#d1d5db' }}>После истечения срока ссылка автоматически перестанет работать.</small>
+        </div>
+
+        {error && <div style={{ color: '#fca5a5' }}>{error}</div>}
+
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            padding: '12px 16px',
+            borderRadius: 8,
+            border: 'none',
+            fontWeight: 600,
+            background: loading ? '#9ca3af' : '#22d3ee',
+            color: '#0f172a',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            transition: 'background 0.2s ease',
+          }}
+        >
+          {loading ? 'Создаём…' : 'Создать инвайт'}
+        </button>
+      </form>
+
+      {recent && (
+        <section style={{ marginTop: 32, padding: 20, border: '1px solid #e5e7eb', borderRadius: 12 }}>
+          <h2 style={{ fontSize: 20, marginBottom: 12 }}>Ссылка готова</h2>
+          <p style={{ marginBottom: 12 }}>
+            Передайте ссылку сотруднику. После регистрации инвайт автоматически пометится использованным.
+          </p>
+          <div style={{ display: 'grid', gap: 8, wordBreak: 'break-all' }}>
+            <div><strong>Email:</strong> {recent.email}</div>
+            {recent.fullName && <div><strong>ФИО:</strong> {recent.fullName}</div>}
+            <div><strong>Роль:</strong> {roleOptions.find((opt) => opt.value === recent.role)?.label ?? recent.role}</div>
+            <div><strong>Действителен до:</strong> {formatExpiresAt(recent.expiresAt)}</div>
+            <div><strong>Ссылка:</strong> {inviteUrl}</div>
+          </div>
+          <button
+            type="button"
+            onClick={copyInvite}
+            style={{
+              marginTop: 16,
+              padding: '10px 14px',
+              borderRadius: 8,
+              border: '1px solid #0ea5e9',
+              background: '#e0f2fe',
+              color: '#0c4a6e',
+              cursor: 'pointer',
+            }}
+          >
+            Скопировать ссылку
+          </button>
+        </section>
+      )}
+
+      {history.length > 0 && (
+        <section style={{ marginTop: 32 }}>
+          <h2 style={{ fontSize: 18, marginBottom: 12 }}>Последние выпущенные инвайты</h2>
+          <div style={{ border: '1px solid #e5e7eb', borderRadius: 12, overflow: 'hidden' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead style={{ background: '#f9fafb', textAlign: 'left' }}>
+                <tr>
+                  <th style={{ padding: '10px 12px', borderBottom: '1px solid #e5e7eb' }}>Email</th>
+                  <th style={{ padding: '10px 12px', borderBottom: '1px solid #e5e7eb' }}>Роль</th>
+                  <th style={{ padding: '10px 12px', borderBottom: '1px solid #e5e7eb' }}>Действует до</th>
+                  <th style={{ padding: '10px 12px', borderBottom: '1px solid #e5e7eb' }}>Код</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.map((item) => (
+                  <tr key={item.code}>
+                    <td style={{ padding: '10px 12px', borderBottom: '1px solid #f3f4f6' }}>{item.email}</td>
+                    <td style={{ padding: '10px 12px', borderBottom: '1px solid #f3f4f6' }}>
+                      {roleOptions.find((opt) => opt.value === item.role)?.label ?? item.role}
+                    </td>
+                    <td style={{ padding: '10px 12px', borderBottom: '1px solid #f3f4f6' }}>{formatExpiresAt(item.expiresAt)}</td>
+                    <td style={{ padding: '10px 12px', borderBottom: '1px solid #f3f4f6', fontFamily: 'monospace' }}>{item.code}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/frontend/static-dashboard/images/oppo-logo.svg
+++ b/frontend/static-dashboard/images/oppo-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-label="OPPO логотип">
+  <rect width="160" height="40" rx="8" fill="#003b2f" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#22c55e" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="600">
+    OPPO
+  </text>
+</svg>

--- a/frontend/static-dashboard/images/oppo-logo@2x.svg
+++ b/frontend/static-dashboard/images/oppo-logo@2x.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-label="OPPO логотип">
+  <rect width="160" height="40" rx="8" fill="#003b2f" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#22c55e" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="600">
+    OPPO
+  </text>
+</svg>

--- a/frontend/static-dashboard/index.html
+++ b/frontend/static-dashboard/index.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OPPO KZ · Responsive Dashboard Prototype</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="app-header" role="banner">
+    <div class="header-inner">
+      <a class="brand" href="#" aria-label="OPPO KZ главная">
+        <picture>
+          <source srcset="images/oppo-logo.svg" type="image/svg+xml" />
+          <img
+            src="images/oppo-logo.svg"
+            srcset="images/oppo-logo.svg 1x, images/oppo-logo@2x.svg 2x"
+            sizes="(min-width: 769px) 160px, 120px"
+            alt="OPPO"
+            width="120"
+            height="32"
+          />
+        </picture>
+        <span class="brand-title">Data Platform</span>
+      </a>
+      <nav class="role-tabs" aria-label="Выбор роли">
+        <button class="tab-button is-active" data-role="admin" type="button">Админ</button>
+        <button class="tab-button" data-role="office" type="button">Офис</button>
+        <button class="tab-button" data-role="supervisor" type="button">Супервизор</button>
+        <button class="tab-button" data-role="promoter" type="button">Промоутер</button>
+        <button class="tab-button" data-role="trainer" type="button">Тренер</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="app-main" tabindex="-1">
+    <section class="dashboard" data-role-panel="admin" aria-labelledby="admin-title">
+      <header class="section-heading">
+        <h1 id="admin-title">Администратор · Управление платформой</h1>
+        <p class="section-subtitle">Мониторинг состояния сервисов и пользователей</p>
+      </header>
+
+      <div class="kpi-grid" data-kpi="admin"></div>
+
+      <section class="panel" aria-labelledby="admin-health-title">
+        <header class="panel-heading">
+          <h2 id="admin-health-title">Системные статусы</h2>
+        </header>
+        <div class="status-grid">
+          <article class="status-card" tabindex="0">
+            <h3>API</h3>
+            <p class="status-value" data-status="api">—</p>
+            <p class="status-note">/api/v1/health</p>
+          </article>
+          <article class="status-card" tabindex="0">
+            <h3>База данных</h3>
+            <p class="status-value" data-status="db">—</p>
+            <p class="status-note">PostgreSQL (Render)</p>
+          </article>
+          <article class="status-card" tabindex="0">
+            <h3>Metabase</h3>
+            <p class="status-value" data-status="bi">—</p>
+            <p class="status-note">bi.oppo.kz</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="admin-users-title">
+        <header class="panel-heading">
+          <h2 id="admin-users-title">Пользователи и роли</h2>
+        </header>
+        <div class="table-wrapper">
+          <table class="responsive-table" data-table="users">
+            <caption class="sr-only">Роли пользователей</caption>
+            <thead>
+              <tr>
+                <th scope="col" data-priority="primary">Имя</th>
+                <th scope="col" data-priority="primary">Роль</th>
+                <th scope="col" data-priority="secondary">Регион</th>
+                <th scope="col" data-priority="tertiary">Последний вход</th>
+                <th scope="col" data-priority="secondary">Статус</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- rows injected -->
+            </tbody>
+          </table>
+          <div class="mobile-table-filter" data-filter-for="users">
+            <label for="users-filter" class="sr-only">Фильтр пользователей</label>
+            <input id="users-filter" type="search" placeholder="Фильтр по имени или роли" />
+          </div>
+        </div>
+      </section>
+    </section>
+
+    <section class="dashboard is-hidden" data-role-panel="office" aria-labelledby="office-title">
+      <header class="section-heading">
+        <h1 id="office-title">Офис · Планирование и аналитика</h1>
+        <p class="section-subtitle">Планы по сети и магазинам, контроль бонусов</p>
+      </header>
+
+      <div class="kpi-grid" data-kpi="office"></div>
+
+      <div class="filter-region" data-filter-context="office">
+        <div class="filter-bar" role="region" aria-label="Фильтры аналитики">
+          <div class="filter-controls" data-filter-controls></div>
+          <button class="filter-clear" type="button" data-action="clear-filters">Сбросить</button>
+        </div>
+        <div class="filter-chips" aria-live="polite" data-filter-chips></div>
+      </div>
+
+      <section class="analytics" data-analytics="office">
+        <nav class="sub-tabs" aria-label="Аналитика офиса">
+          <button class="sub-tab-button is-active" data-target="office-overview" type="button">Все продажи</button>
+          <button class="sub-tab-button" data-target="office-models" type="button">По моделям</button>
+          <button class="sub-tab-button" data-target="office-bonuses" type="button">Бонусы</button>
+        </nav>
+
+        <div class="analytics-panel" data-panel="office-overview">
+          <div class="chart-toolbar">
+            <div class="time-grain" role="group" aria-label="Гранулярность">
+              <button type="button" class="grain-button is-active" data-grain="day">День</button>
+              <button type="button" class="grain-button" data-grain="week">Неделя</button>
+              <button type="button" class="grain-button" data-grain="month">Месяц</button>
+            </div>
+            <div class="metric-toggle" role="group" aria-label="Метрики">
+              <label><input type="checkbox" data-secondary-axis /> Вторая ось (ASP)</label>
+            </div>
+          </div>
+          <div class="chart-shell" role="img" aria-label="Динамика продаж">
+            <div class="chart-placeholder" data-chart="overview"></div>
+          </div>
+          <div class="comparison-chips" aria-live="polite" data-comparisons></div>
+        </div>
+
+        <div class="analytics-panel is-hidden" data-panel="office-models">
+          <div class="chart-shell" role="img" aria-label="Сравнение по моделям">
+            <div class="chart-placeholder" data-chart="models"></div>
+          </div>
+          <div class="legend" data-legend></div>
+        </div>
+
+        <div class="analytics-panel is-hidden" data-panel="office-bonuses">
+          <div class="table-wrapper">
+            <table class="responsive-table" data-table="bonuses">
+              <caption class="sr-only">Выплаты бонусов</caption>
+              <thead>
+              <tr>
+                <th scope="col" data-priority="primary">Магазин</th>
+                <th scope="col" data-priority="primary">Промоутер</th>
+                <th scope="col" data-priority="secondary">План (₸)</th>
+                <th scope="col" data-priority="secondary">Факт (₸)</th>
+                <th scope="col" data-priority="tertiary">Achv%</th>
+                <th scope="col" data-priority="secondary">Бонус</th>
+              </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+            <div class="mobile-table-filter" data-filter-for="bonuses">
+              <label for="bonuses-filter" class="sr-only">Фильтр бонусов</label>
+              <input id="bonuses-filter" type="search" placeholder="Фильтр по магазину" />
+            </div>
+          </div>
+        </div>
+      </section>
+    </section>
+
+    <section class="dashboard is-hidden" data-role-panel="supervisor" aria-labelledby="supervisor-title">
+      <header class="section-heading">
+        <h1 id="supervisor-title">Супервизор · Региональная аналитика</h1>
+        <p class="section-subtitle">Контроль сетей и промоутеров в закреплённых регионах</p>
+      </header>
+
+      <div class="kpi-grid" data-kpi="supervisor"></div>
+
+      <div class="filter-region" data-filter-context="supervisor">
+        <div class="filter-bar" role="region" aria-label="Фильтры супервизора">
+          <div class="filter-controls" data-filter-controls></div>
+          <button class="filter-clear" type="button" data-action="clear-filters">Сбросить</button>
+        </div>
+        <div class="filter-chips" aria-live="polite" data-filter-chips></div>
+      </div>
+
+      <section class="panel" aria-labelledby="supervisor-map-title">
+        <header class="panel-heading">
+          <h2 id="supervisor-map-title">Карта сетей</h2>
+        </header>
+        <div class="map-wrapper">
+          <svg class="map" viewBox="0 0 400 200" role="img" aria-label="Карта Казахстана">
+            <title>Карта регионов Казахстана</title>
+            <rect x="5" y="40" width="390" height="120" rx="12" class="map-plate"></rect>
+            <g class="map-markers" data-marker-group>
+              <g class="map-marker" data-city="Алматы" data-region="Юг" transform="translate(120,110)">
+                <circle r="12"></circle>
+                <text y="4">A</text>
+              </g>
+              <g class="map-marker" data-city="Астана" data-region="Центр" transform="translate(240,80)">
+                <circle r="12"></circle>
+                <text y="4">N</text>
+              </g>
+              <g class="map-marker" data-city="Шымкент" data-region="Юг" transform="translate(160,140)">
+                <circle r="12"></circle>
+                <text y="4">S</text>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </section>
+
+      <section class="panel lazy" data-lazy="cities" aria-labelledby="supervisor-cities-title">
+        <header class="panel-heading">
+          <h2 id="supervisor-cities-title">Города и магазины</h2>
+        </header>
+        <div class="table-wrapper" data-lazy-target>
+          <!-- populated on demand -->
+        </div>
+      </section>
+    </section>
+
+    <section class="dashboard is-hidden" data-role-panel="promoter" aria-labelledby="promoter-title">
+      <header class="section-heading">
+        <h1 id="promoter-title">Промоутер · План vs Факт</h1>
+        <p class="section-subtitle">Личный план и бонусы за месяц</p>
+      </header>
+
+      <div class="kpi-grid" data-kpi="promoter"></div>
+
+      <section class="panel" aria-labelledby="promoter-sales-title">
+        <header class="panel-heading">
+          <h2 id="promoter-sales-title">Продажи по дням</h2>
+        </header>
+        <div class="chart-shell" role="img" aria-label="Личные продажи по дням">
+          <div class="chart-placeholder" data-chart="promoter"></div>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="promoter-bonuses-title">
+        <header class="panel-heading">
+          <h2 id="promoter-bonuses-title">Бонусы</h2>
+        </header>
+        <div class="table-wrapper">
+          <table class="responsive-table" data-table="promoter-bonuses">
+            <caption class="sr-only">Бонусы промоутера</caption>
+            <thead>
+              <tr>
+                <th scope="col" data-priority="primary">Месяц</th>
+                <th scope="col" data-priority="secondary">План (₸)</th>
+                <th scope="col" data-priority="secondary">Факт (₸)</th>
+                <th scope="col" data-priority="tertiary">Achv%</th>
+                <th scope="col" data-priority="primary">Бонус</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <div class="mobile-table-filter" data-filter-for="promoter-bonuses">
+            <label for="promoter-bonuses-filter" class="sr-only">Фильтр бонусов</label>
+            <input id="promoter-bonuses-filter" type="search" placeholder="Фильтр по месяцу" />
+          </div>
+        </div>
+      </section>
+    </section>
+
+    <section class="dashboard is-hidden" data-role-panel="trainer" aria-labelledby="trainer-title">
+      <header class="section-heading">
+        <h1 id="trainer-title">Тренер · Обучение промоутеров</h1>
+        <p class="section-subtitle">План обучения и статус по курсам</p>
+      </header>
+
+      <div class="kpi-grid" data-kpi="trainer"></div>
+
+      <section class="panel" aria-labelledby="trainer-schedule-title">
+        <header class="panel-heading">
+          <h2 id="trainer-schedule-title">Ближайшие тренинги</h2>
+        </header>
+        <div class="table-wrapper">
+          <table class="responsive-table" data-table="training">
+            <caption class="sr-only">Расписание тренингов</caption>
+            <thead>
+              <tr>
+                <th scope="col" data-priority="primary">Дата</th>
+                <th scope="col" data-priority="primary">Город</th>
+                <th scope="col" data-priority="secondary">Тема</th>
+                <th scope="col" data-priority="tertiary">Участники</th>
+                <th scope="col" data-priority="secondary">Статус</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <div class="mobile-table-filter" data-filter-for="training">
+            <label for="training-filter" class="sr-only">Фильтр тренингов</label>
+            <input id="training-filter" type="search" placeholder="Фильтр по теме" />
+          </div>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <div class="modal-backdrop" data-modal-backdrop hidden></div>
+
+  <dialog class="app-modal" data-modal role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+    <div class="modal-content">
+      <header class="modal-header">
+        <h2 id="modal-title">Детали</h2>
+        <button type="button" class="modal-close" data-modal-close aria-label="Закрыть">×</button>
+      </header>
+      <div class="modal-body" data-modal-body></div>
+      <footer class="modal-footer">
+        <button type="button" class="modal-action" data-modal-close>Закрыть</button>
+      </footer>
+    </div>
+  </dialog>
+
+  <template id="city-table-template">
+    <div class="table-wrapper">
+      <table class="responsive-table" data-table="cities">
+        <caption class="sr-only">Города и магазины</caption>
+        <thead>
+          <tr>
+            <th scope="col" data-priority="primary">Город</th>
+            <th scope="col" data-priority="secondary">Сеть</th>
+            <th scope="col" data-priority="secondary">Магазины</th>
+            <th scope="col" data-priority="tertiary">Активные промоутеры</th>
+            <th scope="col" data-priority="secondary">Статус</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div class="mobile-table-filter" data-filter-for="cities">
+        <label for="cities-filter" class="sr-only">Фильтр городов</label>
+        <input id="cities-filter" type="search" placeholder="Фильтр по городу" />
+      </div>
+    </div>
+  </template>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/static-dashboard/script.js
+++ b/frontend/static-dashboard/script.js
@@ -1,0 +1,843 @@
+/**
+ * Responsive dashboard prototype for OPPO KZ.
+ * Pure JS implementation with in-memory demo data.
+ */
+const state = {
+  currentRole: "admin",
+  chart: {
+    grain: "day",
+    secondaryAxis: false,
+  },
+  filters: {
+    office: {
+      scope: ["Все"],
+      period: ["Текущий месяц"],
+      timeGrain: ["День"],
+      models: ["Reno10", "Find X5"],
+      metric: ["Шт."],
+      compare: ["WoW"],
+      lfl: ["LFL выкл"],
+    },
+    supervisor: {
+      scope: ["Юг"],
+      period: ["Текущая неделя"],
+      timeGrain: ["Неделя"],
+      models: ["Reno10"],
+      metric: ["₸"],
+      compare: ["WoW"],
+      lfl: ["LFL вкл"],
+    },
+  },
+};
+
+const filtersConfig = {
+  office: [
+    {
+      key: "scope",
+      label: "Охват",
+      multi: false,
+      options: ["Все", "Сеть", "Магазин"],
+    },
+    {
+      key: "period",
+      label: "Период",
+      multi: false,
+      options: [
+        "Текущая неделя",
+        "Текущий месяц",
+        "Этот квартал",
+        "Произвольный",
+      ],
+    },
+    {
+      key: "timeGrain",
+      label: "Гранулярность",
+      multi: false,
+      options: ["День", "Неделя", "Месяц", "Год"],
+    },
+    {
+      key: "models",
+      label: "Модели",
+      multi: true,
+      options: ["Reno10", "Find X5", "A78", "A17", "Find N3"],
+    },
+    {
+      key: "metric",
+      label: "Метрика",
+      multi: false,
+      options: ["Шт.", "₸", "Achv%", "Bonus"],
+    },
+    {
+      key: "compare",
+      label: "Сравнение",
+      multi: true,
+      options: ["WoW", "MoM", "YoY"],
+    },
+    {
+      key: "lfl",
+      label: "LFL",
+      multi: false,
+      options: ["LFL вкл", "LFL выкл"],
+    },
+  ],
+  supervisor: [
+    {
+      key: "scope",
+      label: "Регион",
+      multi: false,
+      options: ["Юг", "Центр"],
+    },
+    {
+      key: "period",
+      label: "Период",
+      multi: false,
+      options: ["Текущая неделя", "Текущий месяц"],
+    },
+    {
+      key: "timeGrain",
+      label: "Гранулярность",
+      multi: false,
+      options: ["Неделя", "Месяц"],
+    },
+    {
+      key: "models",
+      label: "Модели",
+      multi: true,
+      options: ["Reno10", "A78", "A58"],
+    },
+    {
+      key: "metric",
+      label: "Метрика",
+      multi: false,
+      options: ["₸", "Achv%"],
+    },
+    {
+      key: "compare",
+      label: "Сравнение",
+      multi: true,
+      options: ["WoW", "MoM"],
+    },
+    {
+      key: "lfl",
+      label: "LFL",
+      multi: false,
+      options: ["LFL вкл", "LFL выкл"],
+    },
+  ],
+};
+
+const kpiData = {
+  admin: [
+    { title: "Пользователи", value: "128", note: "активны за 7 дней" },
+    { title: "Ошибки API", value: "3", note: "за 24 часа", variant: "danger" },
+    { title: "Синхронизации", value: "12", note: "выполнено сегодня" },
+  ],
+  office: [
+    { title: "План месяца", value: "₸ 180M", note: "Офис установил" },
+    { title: "Факт", value: "₸ 132M", note: "73% выполнения" },
+    { title: "Бонусный фонд", value: "₸ 8.4M", note: "доступно" },
+  ],
+  supervisor: [
+    { title: "Регион Юг", value: "₸ 72M", note: "4 сети" },
+    { title: "Топ магазин", value: "Mega Alma", note: "₸ 12.5M" },
+    { title: "Промоутеры", value: "38", note: "активны" },
+  ],
+  promoter: [
+    { title: "План месяца", value: "₸ 2.4M", note: "установил офис" },
+    { title: "Факт", value: "₸ 1.86M", note: "78% выполнено" },
+    { title: "Бонус к выплате", value: "₸ 180k", note: "после апрува" },
+  ],
+  trainer: [
+    { title: "Сессии", value: "12", note: "в этом месяце" },
+    { title: "Участники", value: "84", note: "план/факт совпал" },
+    { title: "Оценка", value: "4.8", note: "средний рейтинг" },
+  ],
+};
+
+const tableData = {
+  users: [
+    {
+      name: "Мария Токтарова",
+      role: "office",
+      region: "HQ",
+      lastLogin: "2024-04-10 09:22",
+      status: "active",
+    },
+    {
+      name: "Ержан Абдрахман",
+      role: "supervisor",
+      region: "Юг",
+      lastLogin: "2024-04-10 08:14",
+      status: "active",
+    },
+    {
+      name: "Нурия Бахыт",
+      role: "promoter",
+      region: "Алматы",
+      lastLogin: "2024-04-09 18:33",
+      status: "pending",
+    },
+    {
+      name: "Адиль Серик",
+      role: "trainer",
+      region: "HQ",
+      lastLogin: "2024-04-08 11:08",
+      status: "active",
+    },
+    {
+      name: "Айгерим Иса",
+      role: "admin",
+      region: "HQ",
+      lastLogin: "2024-04-10 10:40",
+      status: "active",
+    },
+  ],
+  bonuses: [
+    {
+      store: "Mega Alma",
+      promoter: "Нурия Бахыт",
+      plan: "₸ 420k",
+      fact: "₸ 480k",
+      achv: "114%",
+      bonus: "₸ 65k",
+    },
+    {
+      store: "Sulpak Esentai",
+      promoter: "Еламан Кайрат",
+      plan: "₸ 380k",
+      fact: "₸ 322k",
+      achv: "85%",
+      bonus: "₸ 28k",
+    },
+    {
+      store: "Mechta Dostyk",
+      promoter: "Айдана Сеит",
+      plan: "₸ 300k",
+      fact: "₸ 280k",
+      achv: "93%",
+      bonus: "₸ 24k",
+    },
+  ],
+  "promoter-bonuses": [
+    {
+      month: "Январь",
+      plan: "₸ 2.0M",
+      fact: "₸ 1.8M",
+      achv: "90%",
+      bonus: "₸ 150k",
+    },
+    {
+      month: "Февраль",
+      plan: "₸ 2.2M",
+      fact: "₸ 2.05M",
+      achv: "93%",
+      bonus: "₸ 165k",
+    },
+    {
+      month: "Март",
+      plan: "₸ 2.4M",
+      fact: "₸ 1.86M",
+      achv: "78%",
+      bonus: "₸ 180k",
+    },
+  ],
+  training: [
+    {
+      date: "12.04.2024",
+      city: "Алматы",
+      topic: "Reno10 камера",
+      attendees: "16",
+      status: "Запланировано",
+    },
+    {
+      date: "18.04.2024",
+      city: "Астана",
+      topic: "Финальный апсейл",
+      attendees: "18",
+      status: "Подтверждено",
+    },
+    {
+      date: "22.04.2024",
+      city: "Шымкент",
+      topic: "Find X5 премиум",
+      attendees: "12",
+      status: "Формируется",
+    },
+  ],
+};
+
+const lazyCityData = [
+  {
+    city: "Алматы",
+    network: "Sulpak",
+    stores: "18",
+    promoters: "24",
+    status: "Работает",
+  },
+  {
+    city: "Астана",
+    network: "Mechta",
+    stores: "12",
+    promoters: "16",
+    status: "Работает",
+  },
+  {
+    city: "Шымкент",
+    network: "Technodom",
+    stores: "9",
+    promoters: "11",
+    status: "Нужен выезд",
+  },
+  {
+    city: "Караганда",
+    network: "Mechta",
+    stores: "6",
+    promoters: "7",
+    status: "Работает",
+  },
+];
+
+const chartCopy = {
+  overview: {
+    day: "График: продажи по дням. Второй показатель ASP включается опцией.",
+    week: "График: недельные продажи. Доступен сравнительный анализ.",
+    month: "График: продажи по месяцам. Отображает накопленный итог.",
+  },
+  models: "Сравнение до 5 моделей. Цвета соответствуют легенде.",
+  promoter: "Личные продажи по дням с плановой линией.",
+};
+
+const comparisonState = [
+  { label: "WoW", value: "+4.2%", trend: "up" },
+  { label: "MoM", value: "+1.8%", trend: "up" },
+  { label: "YoY", value: "−3.4%", trend: "down" },
+];
+
+const statusData = {
+  api: { value: "OK", note: "99.9% uptime" },
+  db: { value: "OK", note: "Latency 22ms" },
+  bi: { value: "OK", note: "Metabase green" },
+};
+
+let activePopover = null;
+let activePopoverContext = null;
+let activePopoverKey = null;
+let activeModalTrigger = null;
+let focusTrapListener = null;
+
+const selectors = {
+  dashboards: document.querySelectorAll("[data-role-panel]"),
+  roleTabs: document.querySelectorAll(".role-tabs .tab-button"),
+  kpiContainers: document.querySelectorAll("[data-kpi]"),
+  tables: document.querySelectorAll("table.responsive-table"),
+  filterRegions: document.querySelectorAll("[data-filter-context]"),
+  analyticsTabs: document.querySelectorAll(".sub-tabs"),
+  analyticsPanels: document.querySelectorAll("[data-panel]"),
+  grainButtons: document.querySelectorAll(".grain-button"),
+  secondaryToggle: document.querySelector("[data-secondary-axis]"),
+  chartPlaceholders: document.querySelectorAll("[data-chart]"),
+  comparisons: document.querySelector("[data-comparisons]"),
+  legend: document.querySelector("[data-legend]"),
+  modal: document.querySelector("[data-modal]"),
+  modalBody: document.querySelector("[data-modal-body]"),
+  modalBackdrop: document.querySelector("[data-modal-backdrop]"),
+  lazySections: document.querySelectorAll("[data-lazy]")
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderAllKpis();
+  populateTables();
+  enhanceTables();
+  hydrateStatuses();
+  setupRoleTabs();
+  setupAnalyticsTabs();
+  setupFilters();
+  setupTableFilters();
+  setupGrainSwitch();
+  setupComparisons();
+  setupLegend();
+  setupMapMarkers();
+  setupLazyLoading();
+  setupModalClose();
+});
+
+function renderAllKpis() {
+  selectors.kpiContainers.forEach((container) => {
+    const key = container.dataset.kpi;
+    container.innerHTML = "";
+    kpiData[key].forEach((item) => {
+      const card = document.createElement("article");
+      card.className = "kpi-card";
+      if (item.variant) {
+        card.dataset.variant = item.variant;
+      }
+      card.innerHTML = `
+        <h3>${item.title}</h3>
+        <p class="kpi-value">${item.value}</p>
+        <p class="kpi-note">${item.note}</p>
+      `;
+      container.append(card);
+    });
+  });
+}
+
+function populateTables() {
+  Object.entries(tableData).forEach(([key, rows]) => {
+    const table = document.querySelector(`table[data-table="${key}"] tbody`);
+    if (!table) return;
+    table.innerHTML = "";
+    rows.forEach((row) => {
+      const tr = document.createElement("tr");
+      Object.values(row).forEach((value) => {
+        const td = document.createElement("td");
+        td.textContent = value;
+        tr.append(td);
+      });
+      table.append(tr);
+    });
+  });
+}
+
+function enhanceTables() {
+  selectors.tables.forEach((table) => {
+    const headers = Array.from(table.querySelectorAll("thead th"));
+    const rows = table.querySelectorAll("tbody tr");
+    rows.forEach((row) => {
+      Array.from(row.children).forEach((cell, index) => {
+        const label = headers[index]?.textContent?.trim() ?? "";
+        const priority = headers[index]?.dataset.priority ?? "primary";
+        cell.setAttribute("data-label", label);
+        cell.dataset.priority = priority;
+      });
+    });
+    headers.forEach((th, index) => {
+      th.addEventListener("click", () => handleSort(table, index));
+    });
+  });
+}
+
+function handleSort(table, columnIndex) {
+  if (window.matchMedia("(max-width: 768px)").matches) {
+    return; // disable sorting on stacked view
+  }
+  const tbody = table.querySelector("tbody");
+  const rows = Array.from(tbody.querySelectorAll("tr"));
+  const isNumeric = rows.every((row) => {
+    const text = row.children[columnIndex]?.textContent?.replace(/[^0-9.-]/g, "");
+    return text !== "";
+  });
+  const current = table.dataset.sortColumn === String(columnIndex) ? table.dataset.sortDir : "asc";
+  const nextDir = current === "asc" ? "desc" : "asc";
+  const sorted = rows.sort((a, b) => {
+    const aText = a.children[columnIndex]?.textContent ?? "";
+    const bText = b.children[columnIndex]?.textContent ?? "";
+    if (isNumeric) {
+      const aNum = parseFloat(aText.replace(/[^0-9.-]/g, "")) || 0;
+      const bNum = parseFloat(bText.replace(/[^0-9.-]/g, "")) || 0;
+      return nextDir === "asc" ? aNum - bNum : bNum - aNum;
+    }
+    return nextDir === "asc" ? aText.localeCompare(bText) : bText.localeCompare(aText);
+  });
+  tbody.innerHTML = "";
+  sorted.forEach((row) => tbody.append(row));
+  table.dataset.sortColumn = String(columnIndex);
+  table.dataset.sortDir = nextDir;
+}
+
+function setupRoleTabs() {
+  selectors.roleTabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const role = tab.dataset.role;
+      if (role === state.currentRole) return;
+      state.currentRole = role;
+      selectors.roleTabs.forEach((btn) => btn.classList.toggle("is-active", btn === tab));
+      selectors.dashboards.forEach((panel) => {
+        panel.classList.toggle("is-hidden", panel.dataset.rolePanel !== role);
+      });
+      document.getElementById("main").focus();
+    });
+  });
+}
+
+function setupAnalyticsTabs() {
+  selectors.analyticsTabs.forEach((nav) => {
+    const buttons = nav.querySelectorAll(".sub-tab-button");
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        buttons.forEach((btn) => btn.classList.toggle("is-active", btn === button));
+        const target = button.dataset.target;
+        const parent = nav.closest(".analytics");
+        parent.querySelectorAll("[data-panel]").forEach((panel) => {
+          panel.classList.toggle("is-hidden", panel.dataset.panel !== target);
+        });
+      });
+    });
+  });
+}
+
+function setupFilters() {
+  selectors.filterRegions.forEach((region) => {
+    const context = region.dataset.filterContext;
+    const controlsContainer = region.querySelector("[data-filter-controls]");
+    const chipsContainer = region.querySelector("[data-filter-chips]");
+    controlsContainer.innerHTML = "";
+    filtersConfig[context].forEach((filter) => {
+      const trigger = document.createElement("button");
+      trigger.type = "button";
+      trigger.className = "filter-trigger";
+      trigger.dataset.filterKey = filter.key;
+      trigger.textContent = filter.label;
+      trigger.addEventListener("click", (event) => {
+        event.stopPropagation();
+        togglePopover(event.currentTarget, context, filter);
+      });
+      controlsContainer.append(trigger);
+    });
+    updateFilterChips(context, chipsContainer);
+  });
+
+  document.addEventListener("click", (event) => {
+    if (
+      activePopover &&
+      !activePopover.contains(event.target) &&
+      event.target !== activePopover.trigger
+    ) {
+      activePopover.remove();
+      activePopover = null;
+      activePopoverContext = null;
+      activePopoverKey = null;
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && activePopover) {
+      activePopover.remove();
+      activePopover = null;
+      activePopoverContext = null;
+      activePopoverKey = null;
+    }
+  });
+
+  document.querySelectorAll("[data-action=\"clear-filters\"]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const context = button.closest("[data-filter-context]")?.dataset.filterContext;
+      if (!context) return;
+      filtersConfig[context].forEach((filter) => {
+        state.filters[context][filter.key] = filter.multi ? [] : [];
+      });
+      if (activePopover) {
+        activePopover.remove();
+        activePopover = null;
+        activePopoverContext = null;
+        activePopoverKey = null;
+      }
+      updateFilterChips(context, button.closest("[data-filter-context]").querySelector("[data-filter-chips]"));
+    });
+  });
+}
+
+function togglePopover(trigger, context, filter) {
+  if (
+    activePopover &&
+    activePopoverContext === context &&
+    activePopoverKey === filter.key
+  ) {
+    activePopover.remove();
+    activePopover = null;
+    activePopoverContext = null;
+    activePopoverKey = null;
+    return;
+  }
+
+  if (activePopover) {
+    activePopover.remove();
+  }
+
+  const popover = document.createElement("div");
+  popover.className = "filter-popover";
+  popover.trigger = trigger;
+
+  const renderOptions = () => {
+    popover.innerHTML = "";
+    filter.options.forEach((option) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "filter-option";
+      button.textContent = option;
+      const current = state.filters[context][filter.key] ?? [];
+      button.setAttribute("aria-pressed", String(current.includes(option)));
+      button.addEventListener("click", () => {
+        applyFilterSelection(context, filter, option);
+        updateFilterChips(
+          context,
+          trigger.closest("[data-filter-context]").querySelector("[data-filter-chips]")
+        );
+        renderOptions();
+      });
+      popover.append(button);
+    });
+  };
+
+  renderOptions();
+  document.body.append(popover);
+  const place = () => {
+    const rect = trigger.getBoundingClientRect();
+    const top = rect.bottom + window.scrollY + 8;
+    const left = rect.left + window.scrollX;
+    const maxLeft = window.innerWidth - popover.offsetWidth - 16;
+    popover.style.top = `${top}px`;
+    popover.style.left = `${Math.max(12, Math.min(left, maxLeft))}px`;
+  };
+  requestAnimationFrame(place);
+  activePopover = popover;
+  activePopoverContext = context;
+  activePopoverKey = filter.key;
+}
+
+function applyFilterSelection(context, filter, option) {
+  const bucket = state.filters[context][filter.key] ?? [];
+  if (filter.multi) {
+    const index = bucket.indexOf(option);
+    if (index > -1) {
+      bucket.splice(index, 1);
+    } else {
+      bucket.push(option);
+    }
+    state.filters[context][filter.key] = bucket;
+  } else {
+    state.filters[context][filter.key] = bucket[0] === option ? [] : [option];
+  }
+}
+
+function updateFilterChips(context, container) {
+  container.innerHTML = "";
+  const filters = state.filters[context];
+  Object.entries(filters).forEach(([key, values]) => {
+    values.filter(Boolean).forEach((value) => {
+      const chip = document.createElement("span");
+      chip.className = "filter-chip";
+      chip.innerHTML = `${value} <button type="button" aria-label="Убрать ${value}">×</button>`;
+      chip.querySelector("button").addEventListener("click", () => {
+        state.filters[context][key] = state.filters[context][key].filter((item) => item !== value);
+        updateFilterChips(context, container);
+      });
+      container.append(chip);
+    });
+  });
+}
+
+function setupTableFilters() {
+  document.querySelectorAll(".mobile-table-filter input").forEach((input) => {
+    if (input.dataset.bound === "true") return;
+    const tableKey = input.closest(".mobile-table-filter").dataset.filterFor;
+    const table = document.querySelector(`table[data-table="${tableKey}"] tbody`);
+    input.addEventListener("input", () => {
+      const query = input.value.toLowerCase();
+      if (!table) return;
+      Array.from(table.querySelectorAll("tr")).forEach((row) => {
+        const visible = row.textContent.toLowerCase().includes(query);
+        row.style.display = visible ? "" : "none";
+      });
+    });
+    input.dataset.bound = "true";
+  });
+}
+
+function setupGrainSwitch() {
+  selectors.grainButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      selectors.grainButtons.forEach((btn) => btn.classList.toggle("is-active", btn === button));
+      state.chart.grain = button.dataset.grain;
+      renderChartCopy();
+    });
+  });
+  if (selectors.secondaryToggle) {
+    selectors.secondaryToggle.addEventListener("change", (event) => {
+      state.chart.secondaryAxis = Boolean(event.target.checked);
+      renderChartCopy();
+    });
+  }
+  renderChartCopy();
+}
+
+function renderChartCopy() {
+  selectors.chartPlaceholders.forEach((placeholder) => {
+    const key = placeholder.dataset.chart;
+    if (key === "overview") {
+      const grainCopy = chartCopy.overview[state.chart.grain];
+      const axis = state.chart.secondaryAxis ? " Включена вторая ось ASP." : "";
+      placeholder.textContent = `${grainCopy}${axis}`;
+    } else {
+      placeholder.textContent = chartCopy[key];
+    }
+  });
+}
+
+function setupComparisons() {
+  if (!selectors.comparisons) return;
+  selectors.comparisons.innerHTML = "";
+  comparisonState.forEach((item) => {
+    const chip = document.createElement("span");
+    chip.className = "comparison-chip";
+    chip.dataset.trend = item.trend;
+    chip.textContent = `${item.label}: ${item.value}`;
+    selectors.comparisons.append(chip);
+  });
+}
+
+function setupLegend() {
+  if (!selectors.legend) return;
+  const colors = ["#22c55e", "#38bdf8", "#f97316", "#a855f7", "#facc15"];
+  const models = filtersConfig.office.find((item) => item.key === "models").options.slice(0, 5);
+  selectors.legend.innerHTML = "";
+  models.forEach((model, index) => {
+    const item = document.createElement("div");
+    item.className = "legend-item";
+    item.innerHTML = `
+      <span class="legend-swatch" style="background:${colors[index % colors.length]}"></span>
+      <span>${model}</span>
+    `;
+    selectors.legend.append(item);
+  });
+}
+
+function setupMapMarkers() {
+  const markers = document.querySelectorAll(".map-marker");
+  markers.forEach((marker) => {
+    marker.setAttribute("tabindex", "0");
+    const showDetails = (event) => {
+      event.preventDefault();
+      const city = marker.dataset.city;
+      const region = marker.dataset.region;
+      openModal(
+        `<p><strong>${city}</strong></p><p>Регион: ${region}</p><p>Оборот за месяц: ₸ ${(Math.random() * 12 + 3).toFixed(1)}M</p>`,
+        `Магазины · ${city}`,
+        marker
+      );
+    };
+    marker.addEventListener("click", showDetails);
+    marker.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        showDetails(event);
+      }
+    });
+  });
+
+  const isTouch = matchMedia("(pointer: coarse)").matches;
+  if (isTouch) {
+    markers.forEach((marker) => {
+      marker.classList.add("touch-target");
+    });
+  }
+}
+
+function setupLazyLoading() {
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        if (entry.target.dataset.lazy === "cities") {
+          renderCityTable(entry.target.querySelector("[data-lazy-target]"));
+        }
+        obs.unobserve(entry.target);
+      }
+    });
+  }, {
+    rootMargin: "200px 0px",
+  });
+  selectors.lazySections.forEach((section) => observer.observe(section));
+}
+
+function renderCityTable(container) {
+  const template = document.getElementById("city-table-template");
+  if (!template) return;
+  const fragment = template.content.cloneNode(true);
+  const tbody = fragment.querySelector("tbody");
+  lazyCityData.forEach((row) => {
+    const tr = document.createElement("tr");
+    Object.values(row).forEach((value) => {
+      const td = document.createElement("td");
+      td.textContent = value;
+      tr.append(td);
+    });
+    tbody.append(tr);
+  });
+  container.innerHTML = "";
+  container.append(fragment);
+  enhanceTables();
+  setupTableFilters();
+}
+
+function hydrateStatuses() {
+  Object.entries(statusData).forEach(([key, payload]) => {
+    const valueEl = document.querySelector(`[data-status="${key}"]`);
+    if (!valueEl) return;
+    valueEl.textContent = payload.value;
+    const noteEl = valueEl.nextElementSibling;
+    if (noteEl) {
+      noteEl.textContent = payload.note;
+    }
+  });
+}
+
+function setupModalClose() {
+  const modal = selectors.modal;
+  const closeButtons = modal.querySelectorAll("[data-modal-close]");
+  closeButtons.forEach((button) => button.addEventListener("click", closeModal));
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && !modal.hasAttribute("hidden")) {
+      closeModal();
+    }
+  });
+}
+
+function openModal(content, title, trigger) {
+  const modal = selectors.modal;
+  const backdrop = selectors.modalBackdrop;
+  selectors.modalBody.innerHTML = content;
+  modal.querySelector("#modal-title").textContent = title;
+  activeModalTrigger = trigger instanceof HTMLElement ? trigger : null;
+  const isSheet = window.matchMedia("(max-width: 768px)").matches;
+  modal.dataset.mode = isSheet ? "sheet" : "dialog";
+  modal.setAttribute("open", "");
+  modal.removeAttribute("hidden");
+  backdrop.hidden = false;
+  backdrop.dataset.active = "true";
+  document.body.style.overflow = "hidden";
+  const focusable = modal.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const trap = (event) => {
+    if (event.key !== "Tab") return;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+  focusTrapListener = trap;
+  document.addEventListener("keydown", focusTrapListener);
+  if (first) first.focus();
+}
+
+function closeModal() {
+  const modal = selectors.modal;
+  const backdrop = selectors.modalBackdrop;
+  modal.setAttribute("hidden", "");
+  modal.removeAttribute("open");
+  modal.removeAttribute("data-mode");
+  backdrop.hidden = true;
+  backdrop.dataset.active = "false";
+  selectors.modalBody.innerHTML = "";
+  document.body.style.overflow = "";
+  if (focusTrapListener) {
+    document.removeEventListener("keydown", focusTrapListener);
+    focusTrapListener = null;
+  }
+  if (activeModalTrigger instanceof HTMLElement) {
+    activeModalTrigger.focus();
+  }
+}

--- a/frontend/static-dashboard/style.css
+++ b/frontend/static-dashboard/style.css
@@ -1,0 +1,867 @@
+:root {
+  --color-bg: #0f172a;
+  --color-surface: #111827;
+  --color-panel: #1e293b;
+  --color-border: rgba(148, 163, 184, 0.2);
+  --color-text: #e2e8f0;
+  --color-muted: #94a3b8;
+  --color-accent: #22c55e;
+  --color-accent-dark: #16a34a;
+  --color-danger: #f97316;
+  --color-focus: rgba(59, 130, 246, 0.7);
+  --shadow-card: 0 12px 30px rgba(15, 23, 42, 0.45);
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --header-height: 76px;
+  color-scheme: dark;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #1e293b, #0f172a);
+  color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select {
+  font-family: inherit;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.92);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px clamp(16px, 4vw, 48px);
+  min-height: var(--header-height);
+  gap: 16px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand-title {
+  display: none;
+  font-size: 0.875rem;
+  color: var(--color-muted);
+}
+
+.role-tabs {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: thin;
+}
+
+.role-tabs::-webkit-scrollbar {
+  height: 4px;
+}
+
+.role-tabs::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+}
+
+.tab-button {
+  scroll-snap-align: start;
+  min-width: 120px;
+  padding: 12px 18px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--color-muted);
+  font-weight: 500;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.tab-button:focus-visible,
+.sub-tab-button:focus-visible,
+.grain-button:focus-visible,
+.filter-clear:focus-visible,
+.modal-close:focus-visible,
+.modal-action:focus-visible,
+.map-marker:focus-visible,
+.filter-chip button:focus-visible,
+.filter-trigger:focus-visible,
+.status-card:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.tab-button:hover,
+.tab-button:focus-visible {
+  background: rgba(148, 163, 184, 0.14);
+}
+
+.tab-button.is-active {
+  color: var(--color-text);
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.2);
+}
+
+.app-main {
+  padding: clamp(16px, 4vw, 48px);
+  display: grid;
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.dashboard {
+  display: grid;
+  gap: clamp(20px, 3vw, 28px);
+}
+
+.section-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.section-heading h1 {
+  font-size: clamp(1.4rem, 1.6vw + 1rem, 2rem);
+  margin: 0;
+}
+
+.section-subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.kpi-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.kpi-card {
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(160deg, rgba(34, 197, 94, 0.18), rgba(30, 41, 59, 0.6));
+  border: 1px solid rgba(34, 197, 94, 0.2);
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 12px;
+}
+
+.kpi-card[data-variant="danger"] {
+  background: linear-gradient(160deg, rgba(249, 115, 22, 0.2), rgba(30, 41, 59, 0.6));
+  border-color: rgba(249, 115, 22, 0.4);
+}
+
+.kpi-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.kpi-value {
+  font-size: clamp(1.6rem, 1vw + 1.2rem, 2.3rem);
+  font-weight: 600;
+}
+
+.kpi-note {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.panel {
+  padding: clamp(20px, 3vw, 28px);
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 20px;
+}
+
+.panel-heading h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.status-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.status-card {
+  background: rgba(30, 41, 59, 0.68);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 18px;
+  display: grid;
+  gap: 10px;
+}
+
+.status-card h3 {
+  margin: 0;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.status-value {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.status-note {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.sub-tabs {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.sub-tab-button {
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid transparent;
+  color: var(--color-muted);
+  font-weight: 500;
+  min-height: 44px;
+}
+
+.sub-tab-button.is-active {
+  color: var(--color-text);
+  border-color: rgba(34, 197, 94, 0.5);
+  background: rgba(34, 197, 94, 0.14);
+}
+
+.analytics-panel {
+  display: grid;
+  gap: 20px;
+}
+
+.chart-shell {
+  position: relative;
+  min-height: 220px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.2));
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.chart-placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.95rem;
+  padding: 16px;
+  text-align: center;
+}
+
+.chart-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.time-grain,
+.metric-toggle {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.grain-button {
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--color-muted);
+  min-height: 44px;
+}
+
+.grain-button.is-active {
+  color: var(--color-text);
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.metric-toggle label {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.comparison-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.comparison-chip {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.14);
+  font-size: 0.85rem;
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.comparison-chip[data-trend="up"] {
+  color: var(--color-accent);
+}
+
+.comparison-chip[data-trend="down"] {
+  color: var(--color-danger);
+}
+
+.legend {
+  display: grid;
+  gap: 12px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.table-wrapper {
+  position: relative;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  overflow: hidden;
+}
+
+.responsive-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.responsive-table caption {
+  color: var(--color-muted);
+  text-align: left;
+  padding: 12px;
+}
+
+.responsive-table th,
+.responsive-table td {
+  padding: 16px 20px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+  font-size: 0.95rem;
+}
+
+.responsive-table th {
+  color: rgba(226, 232, 240, 0.76);
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.responsive-table tbody tr:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.mobile-table-filter {
+  display: none;
+  padding: 12px;
+  background: rgba(15, 23, 42, 0.68);
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.mobile-table-filter input {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--color-text);
+}
+
+.filter-region {
+  display: grid;
+  gap: 12px;
+}
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px clamp(12px, 3vw, 20px);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.6);
+  align-items: center;
+}
+
+.filter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  flex: 1;
+}
+
+.filter-trigger {
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--color-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+}
+
+.filter-clear {
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--color-muted);
+  min-height: 44px;
+}
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.18);
+  color: var(--color-text);
+}
+
+.filter-chip button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  padding: 0;
+  cursor: pointer;
+}
+
+.filter-popover {
+  position: absolute;
+  z-index: 30;
+  min-width: 220px;
+  max-width: 320px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: var(--shadow-card);
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.filter-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-text);
+  min-height: 44px;
+}
+
+.filter-option[aria-pressed="true"] {
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.map-wrapper {
+  position: relative;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: clamp(12px, 4vw, 24px);
+}
+
+.map {
+  width: 100%;
+  height: auto;
+}
+
+.map-plate {
+  fill: rgba(148, 163, 184, 0.12);
+}
+
+.map-marker {
+  cursor: pointer;
+  text-anchor: middle;
+  font-size: 12px;
+  font-weight: 600;
+  fill: var(--color-text);
+  outline: none;
+}
+
+.map-marker circle {
+  fill: rgba(34, 197, 94, 0.3);
+  stroke: rgba(34, 197, 94, 0.6);
+  stroke-width: 2;
+}
+
+.map-marker text {
+  pointer-events: none;
+}
+
+.map-marker.touch-target circle {
+  r: 18;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.6);
+  backdrop-filter: blur(10px);
+  z-index: 40;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.modal-backdrop[data-active="true"] {
+  opacity: 1;
+}
+
+.app-modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+  width: min(640px, 92vw);
+  max-height: 90vh;
+}
+
+.app-modal::backdrop {
+  display: none;
+}
+
+.modal-content {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: rgba(15, 23, 42, 0.98);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: var(--shadow-card);
+  max-height: inherit;
+}
+
+.modal-header,
+.modal-footer {
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.modal-body {
+  padding: 0 20px 20px;
+  overflow-y: auto;
+  max-height: 60vh;
+}
+
+.modal-close,
+.modal-action {
+  border: none;
+  background: rgba(34, 197, 94, 0.16);
+  color: var(--color-text);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.modal-close {
+  background: transparent;
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.modal-action:hover {
+  background: rgba(34, 197, 94, 0.26);
+}
+
+.app-modal[data-mode="sheet"] {
+  width: 100vw;
+  max-height: 90vh;
+  height: min(540px, 90vh);
+  border-radius: 0;
+}
+
+.app-modal[data-mode="sheet"] .modal-content {
+  border-radius: 24px 24px 0 0;
+  height: 100%;
+  transform: translateY(100%);
+  animation: sheet-in 0.3s ease forwards;
+}
+
+@keyframes sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.app-modal[data-mode="sheet"] .modal-body {
+  max-height: calc(100vh - 180px);
+}
+
+.app-modal[data-mode="dialog"] .modal-content {
+  animation: fade-up 0.28s ease forwards;
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+/* Breakpoints */
+
+@media (min-width: 481px) {
+  :root {
+    --header-height: 84px;
+  }
+  .brand-title {
+    display: inline;
+  }
+}
+
+@media (min-width: 769px) {
+  .role-tabs {
+    justify-content: flex-end;
+    overflow: visible;
+  }
+
+  .tab-button {
+    min-width: auto;
+  }
+
+  .chart-shell {
+    min-height: 260px;
+  }
+
+  .legend {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .filter-bar {
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 1025px) {
+  .app-main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .analytics-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .chart-shell {
+    min-height: 320px;
+  }
+
+  .map-wrapper {
+    padding: 28px;
+  }
+
+  [data-panel="office-models"] {
+    grid-template-columns: minmax(0, 1fr) 260px;
+    align-items: start;
+  }
+}
+
+/* Table to cards */
+
+@media (max-width: 768px) {
+  .responsive-table thead {
+    display: none;
+  }
+
+  .responsive-table,
+  .responsive-table tbody,
+  .responsive-table tr,
+  .responsive-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .responsive-table tr {
+    border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+    padding: 12px 16px;
+  }
+
+  .responsive-table td {
+    border: none;
+    padding: 6px 0;
+    font-size: 0.95rem;
+  }
+
+  .responsive-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.6);
+    margin-bottom: 2px;
+  }
+
+  .responsive-table td[data-priority="tertiary"] {
+    display: none;
+  }
+
+  .responsive-table tbody tr:hover {
+    background: transparent;
+  }
+
+  .mobile-table-filter {
+    display: block;
+  }
+
+  .chart-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .time-grain,
+  .metric-toggle {
+    justify-content: space-between;
+  }
+
+  .comparison-chips {
+    flex-direction: column;
+  }
+
+  .legend {
+    grid-template-columns: 1fr;
+  }
+
+  .app-modal {
+    margin: 0;
+    width: 100vw;
+  }
+
+  .metric-toggle {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .header-inner {
+    padding: 12px 14px;
+  }
+
+  .tab-button {
+    min-width: 140px;
+    padding: 12px 20px;
+  }
+
+  .panel {
+    padding: 18px;
+  }
+
+  .kpi-card {
+    padding: 18px;
+  }
+
+  .map-marker circle {
+    r: 16;
+  }
+
+  .map-marker {
+    font-size: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add the missing Tailwind/PostCSS toolchain so the Vite bundle compiles
- rebuild the Invites management page with a default export and invite issuance workflow to unblock routing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e178dd3c68832f85891d72ddee5a73