### PR TITLE
feat: provision aws prod infra and ci pipelines

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,138 @@
+name: backend-ci
+
+on:
+  push:
+    branches: ["develop"]
+    tags: ["v*", "release-*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  context:
+    name: Determine deployment context
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_env: ${{ steps.detect.outputs.deploy_env }}
+      release_tag: ${{ steps.detect.outputs.release_tag }}
+      image_tag: ${{ steps.detect.outputs.image_tag }}
+    steps:
+      - name: Detect target
+        id: detect
+        run: |
+          ref="${GITHUB_REF}"
+          if [[ "$ref" == refs/tags/* ]]; then
+            echo "deploy_env=prod" >> "$GITHUB_OUTPUT"
+            echo "release_tag=${ref#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${ref#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_env=staging" >> "$GITHUB_OUTPUT"
+            echo "release_tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+  tests:
+    name: Backend tests (matrix)
+    needs: context
+    uses: ./.github/workflows/reusable-python-ci.yml
+    with:
+      python-versions: '["3.11", "3.12"]'
+      cache-key-suffix: "-backend"
+
+  build-and-deploy:
+    name: Build, push and deploy to ECS
+    needs: [context, tests]
+    if: needs.context.outputs.deploy_env == 'prod'
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: me-central-1
+      ECR_REPOSITORY: oppo-kz/prod/backend
+      IMAGE_TAG: ${{ needs.context.outputs.image_tag }}
+      TASK_FAMILY: oppo-kz-prod-backend
+      ECS_CLUSTER: ${{ secrets.AWS_ECS_CLUSTER_NAME }}
+      ECS_SERVICE: ${{ secrets.AWS_ECS_SERVICE_NAME }}
+      ECS_SUBNETS: ${{ secrets.AWS_ECS_SUBNETS }}
+      ECS_SECURITY_GROUPS: ${{ secrets.AWS_ECS_SECURITY_GROUPS }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        working-directory: backend
+        run: |
+          docker build -t ${ECR_REPOSITORY}:${IMAGE_TAG} .
+          docker tag ${ECR_REPOSITORY}:${IMAGE_TAG} ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
+
+      - name: Push image to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          docker push ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
+
+      - name: Render new task definition
+        id: render
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          set -euo pipefail
+          aws ecs describe-task-definition --task-definition ${TASK_FAMILY} > task-def.json
+          cat task-def.json | jq '.taskDefinition | {family, networkMode, requiresCompatibilities, cpu, memory, executionRoleArn, taskRoleArn, containerDefinitions, volumes, placementConstraints, runtimePlatform}' \
+            | jq '.containerDefinitions[0].image = "'"${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"'"' > new-task-def.json
+          TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json file://new-task-def.json --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "task_definition_arn=${TASK_DEF_ARN}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Alembic migrations (Fargate one-off)
+        env:
+          TASK_DEFINITION_ARN: ${{ steps.render.outputs.task_definition_arn }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra SUBNETS <<< "${ECS_SUBNETS}"
+          IFS=',' read -ra SGS <<< "${ECS_SECURITY_GROUPS}"
+          SUBNET_ARGS=$(printf '"%s",' "${SUBNETS[@]}")
+          SG_ARGS=$(printf '"%s",' "${SGS[@]}")
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "${ECS_CLUSTER}" \
+            --launch-type FARGATE \
+            --task-definition "${TASK_DEFINITION_ARN}" \
+            --count 1 \
+            --platform-version 1.4.0 \
+            --network-configuration "{\"awsvpcConfiguration\":{\"assignPublicIp\":\"DISABLED\",\"subnets\":[${SUBNET_ARGS%,}],\"securityGroups\":[${SG_ARGS%,}]}}" \
+            --overrides '{"containerOverrides":[{"name":"backend","command":["alembic","-c","alembic.ini","upgrade","head"]}]}' \
+            --query 'tasks[0].taskArn' --output text)
+          aws ecs wait tasks-stopped --cluster "${ECS_CLUSTER}" --tasks "${TASK_ARN}"
+          EXIT_CODE=$(aws ecs describe-tasks --cluster "${ECS_CLUSTER}" --tasks "${TASK_ARN}" --query 'tasks[0].containers[0].exitCode' --output text)
+          if [ "${EXIT_CODE}" != "0" ]; then
+            echo "Alembic migration failed" >&2
+            exit 1
+          fi
+
+      - name: Deploy new revision to ECS service
+        env:
+          TASK_DEFINITION_ARN: ${{ steps.render.outputs.task_definition_arn }}
+        run: |
+          aws ecs update-service --cluster "${ECS_CLUSTER}" --service "${ECS_SERVICE}" --task-definition "${TASK_DEFINITION_ARN}" --force-new-deployment
+
+      - name: Wait for service stability
+        run: |
+          aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"
+
+      - name: Store task definition artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecs-task-def-${{ needs.context.outputs.image_tag }}
+          path: new-task-def.json

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,101 @@
+name: frontend-ci
+
+on:
+  push:
+    branches: ["develop"]
+    tags: ["v*", "release-*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  context:
+    name: Determine deployment context
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_env: ${{ steps.detect.outputs.deploy_env }}
+      release_tag: ${{ steps.detect.outputs.release_tag }}
+    steps:
+      - name: Detect target
+        id: detect
+        run: |
+          ref="${GITHUB_REF}"
+          if [[ "$ref" == refs/tags/* ]]; then
+            echo "deploy_env=prod" >> "$GITHUB_OUTPUT"
+            echo "release_tag=${ref#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_env=staging" >> "$GITHUB_OUTPUT"
+            echo "release_tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build frontend artifact
+    needs: context
+    uses: ./.github/workflows/reusable-frontend-ci.yml
+    with:
+      node-version: '20'
+      build-command: 'npm run build'
+
+  deploy-render:
+    name: Deploy staging to Render
+    needs: [context, build]
+    if: needs.context.outputs.deploy_env == 'staging'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist-${{ github.sha }}
+          path: dist
+
+      - name: Trigger Render static site deploy
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_STATIC_SITE_ID: ${{ secrets.RENDER_STATIC_SITE_ID }}
+        run: |
+          if [[ -z "${RENDER_API_KEY}" || -z "${RENDER_STATIC_SITE_ID}" ]]; then
+            echo "Render credentials not configured; skipping" && exit 0
+          fi
+          DEPLOY_ID=$(curl -sS -X POST "https://api.render.com/v1/static-sites/${RENDER_STATIC_SITE_ID}/deploys" \
+            -H "Authorization: Bearer ${RENDER_API_KEY}" -H "Content-Type: application/json" \
+            --data '{}'
+          )
+          echo "Triggered deploy: ${DEPLOY_ID}"
+
+  deploy-aws:
+    name: Upload to S3 and invalidate CloudFront
+    needs: [context, build]
+    if: needs.context.outputs.deploy_env == 'prod'
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: me-central-1
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist-${{ github.sha }}
+          path: dist
+
+      - name: Sync to S3 static bucket
+        run: |
+          aws s3 sync dist/ s3://${{ secrets.AWS_FRONTEND_BUCKET }} --delete --cache-control max-age=31536000,public
+          aws s3 cp dist/index.html s3://${{ secrets.AWS_FRONTEND_BUCKET }}/index.html --cache-control no-cache --content-type text/html
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'
+
+      - name: Publish build manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-manifest-${{ needs.context.outputs.release_tag }}
+          path: dist
+          if-no-files-found: error

--- a/.github/workflows/reusable-frontend-ci.yml
+++ b/.github/workflows/reusable-frontend-ci.yml
@@ -1,0 +1,49 @@
+name: reusable-frontend-ci
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Версия Node.js"
+        required: true
+        type: string
+      build-command:
+        description: "Команда сборки"
+        required: false
+        default: "npm run build"
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: ${{ inputs.build-command }}
+
+      - name: Upload dist artifact
+        id: artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist-${{ github.sha }}
+          path: frontend/dist
+
+      - name: Upload build info
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build-info-${{ github.sha }}
+          path: frontend/package.json

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -1,0 +1,58 @@
+name: reusable-python-ci
+
+on:
+  workflow_call:
+    inputs:
+      python-versions:
+        description: "JSON массив версий Python"
+        required: true
+        type: string
+      cache-key-suffix:
+        description: "Суффикс ключа кэша"
+        required: false
+        default: ""
+        type: string
+    secrets:
+      additional-pip-index:
+        required: false
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{ fromJson(inputs.python-versions) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ matrix.python }}-${{ hashFiles('**/requirements*.txt', 'pyproject.toml') }}${{ inputs.cache-key-suffix }}
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Run backend tests
+        env:
+          PYTHONPATH: backend
+        run: |
+          pytest backend/tests -q
+
+      - name: Upload pytest artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-report-${{ matrix.python }}
+          path: backend/.pytest_cache
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ infra/
   render.yaml
   render.md
   scripts/
+  aws/
+    README.md
+    prod/
 .env.example
 ```
 
@@ -45,6 +48,11 @@ infra/
 - `SECRET_KEY`
 - `CORS_ORIGINS`
 - `VITE_API_URL`
+- дополнительные переменные для продакшена описаны в `infra/ENV.md`
+
+## Инфраструктура
+- **Staging** — Render (см. `infra/render.md`, `render.yaml`). Автодеплой из ветки `develop` через GitHub Actions `frontend-ci`/`deploy_render` и backend веб-сервис Render.
+- **Production** — AWS (Terraform в `infra/aws/prod`). Bootstrap-скрипт: `scripts/bootstrap_aws_infra.sh`.
 
 ## Запуск локально
 ```bash

--- a/infra/ENV.md
+++ b/infra/ENV.md
@@ -1,0 +1,30 @@
+# Переменные окружения
+
+## Backend (FastAPI)
+| Variable | Назначение | Где хранить |
+|----------|------------|-------------|
+| `DATABASE_URL` | Подключение к Postgres | AWS SSM Parameter Store `/oppo-kz/prod/DATABASE_URL`, Render secret для стейджинга |
+| `SECRET_KEY` | Секрет JWT/шифрования | AWS Secrets Manager `/oppo-kz/prod/backend_env`, Render secret |
+| `CORS_ORIGINS` | Разрешённые источники | AWS Secrets Manager `/oppo-kz/prod/backend_env`, Render environment |
+| `S3_BUCKET` | Рабочий бакет для файлов | AWS Secrets Manager `/oppo-kz/prod/backend_env` |
+| `AWS_REGION` | Регион AWS | AWS Secrets Manager `/oppo-kz/prod/backend_env` |
+| `SENTRY_DSN` | DSN для Sentry backend | AWS Secrets Manager `/oppo-kz/prod/sentry_backend_dsn`, Render secret |
+| `FEATURE_AI_INSIGHTS` | Фичефлаг AI аналитики | AWS Secrets Manager `/oppo-kz/prod/backend_env`, Render env |
+| `OPENAI_API_KEY` | Опциональный ключ OpenAI | AWS SSM Parameter `/oppo-kz/prod/openai_api_key`, Render secret |
+
+## Frontend (Vite)
+| Variable | Назначение | Где хранить |
+|----------|------------|-------------|
+| `VITE_API_URL` | Базовый URL API | Render static site env (`https://<staging-backend>`), S3 build-time переменная через GitHub Actions | 
+
+## Порядок обновления секретов
+1. Обновите секреты в AWS Secrets Manager/SSM CLI или через консоль.
+2. В GitHub → Settings → Secrets and variables → Actions добавьте:
+   - `AWS_IAM_ROLE_TO_ASSUME`, `AWS_ECS_CLUSTER_NAME`, `AWS_ECS_SERVICE_NAME`, `AWS_ECS_SUBNETS`, `AWS_ECS_SECURITY_GROUPS`, `AWS_FRONTEND_BUCKET`, `AWS_CLOUDFRONT_DISTRIBUTION_ID`.
+   - Render API ключи: `RENDER_API_KEY`, `RENDER_BACKEND_SERVICE_ID`, `RENDER_STATIC_SITE_ID`.
+3. Для стейджинга (Render) используйте `render.yaml` и панель Render для установки `DATABASE_URL`, `SECRET_KEY`, `CORS_ORIGINS`, `VITE_API_URL`.
+
+## Домены
+- **Production frontend**: `app.oppo-kz.kz` → CloudFront (Terraform создаёт alias запись).
+- **Production API**: ALB DNS `oppo-kz-prod-alb-*.amazonaws.com` или пользовательский поддомен `api.oppo-kz.kz` (создать CNAME/ALIAS в Route53).
+- **Staging**: Render выдаёт свои URL вида `https://oppo-kz-staging.onrender.com`. Пропишите их в `CORS_ORIGINS` и `VITE_API_URL`.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -1,0 +1,33 @@
+# AWS Prod инфраструктура
+
+## Структура Terraform
+- `infra/aws/prod/*.tf` — описание VPC, ECS Fargate, RDS, S3, CloudFront, WAF, EventBridge и секретов.
+- Используются два провайдера AWS: основной (me-central-1) и алиас `us_east_1` для ACM/CloudFront.
+
+## Шаги развёртывания
+1. Выполнить `scripts/bootstrap_aws_infra.sh` для подготовки ECR и запроса сертификата ACM.
+2. После подтверждения сертификата в Route53 перейти в каталог `infra/aws/prod` и выполнить:
+   ```bash
+   terraform init
+   terraform workspace select prod || terraform workspace new prod
+   terraform plan -var "project=oppo-kz" -var "container_image=<ACCOUNT_ID>.dkr.ecr.me-central-1.amazonaws.com/oppo-kz/prod/backend:latest" -var "db_username=oppo" -var "db_password=<secure>" -var "sentry_backend_dsn=<dsn>" -var "sentry_frontend_dsn=<dsn>" -var "hosted_zone_id=<ZID>"
+   terraform apply
+   ```
+3. После создания CloudFront обновить запись A в внешнем DNS, если используется сторонний регистратор.
+
+## Настройка домена
+- В Route53 hosted zone `oppo-kz.kz` будет создана A-запись `app.oppo-kz.kz` (alias на CloudFront).
+- Для backend использовать поддомен `api.oppo-kz.kz` (создать отдельно и направить на ALB, если потребуется публичный API). В противном случае — доступ только через ALB DNS.
+
+## Переменные окружения и секреты
+- Secrets Manager: `/oppo-kz/prod/backend_env`, `/oppo-kz/prod/db_password`, `/oppo-kz/prod/sentry_*`.
+- Parameter Store: `/oppo-kz/prod/DATABASE_URL`, `/oppo-kz/prod/openai_api_key`.
+- CI/CD workflows обращаются к этим секретам через IAM роли GitHub OIDC (см. `.github/workflows`).
+
+## Мониторинг и логирование
+- CloudWatch log groups: `/ecs/oppo-kz-prod-backend`, `/aws/events/oppo-kz-prod-scheduled`.
+- Рекомендуется подключить Sentry DSN в Secrets Manager, чтобы ECS сервис пробросил переменные.
+
+## Крон-задачи
+- EventBridge запускает Fargate задачи с тегом `job` (sales/pops/anomalies каждую час; план-факт/seasonality/bonus_liability в 02:00 UTC).
+- Backend должен обрабатывать входящий payload JSON с ключом `job`.

--- a/infra/aws/prod/acm.tf
+++ b/infra/aws/prod/acm.tf
@@ -1,0 +1,34 @@
+resource "aws_acm_certificate" "primary" {
+  provider          = aws.us_east_1
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+  subject_alternative_names = [var.domain_name]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.tags
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.primary.domain_validation_options : dvo.domain_name => {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  }
+
+  zone_id = var.hosted_zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "primary" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.primary.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}

--- a/infra/aws/prod/alb.tf
+++ b/infra/aws/prod/alb.tf
@@ -1,0 +1,124 @@
+resource "aws_lb" "this" {
+  name               = "${var.project}-${var.environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [for s in aws_subnet.public : s.id]
+
+  access_logs {
+    bucket  = aws_s3_bucket.files.bucket
+    prefix  = "alb-logs"
+    enabled = true
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-alb" })
+}
+
+resource "aws_lb_target_group" "backend" {
+  name        = "${var.project}-${var.environment}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 3
+    unhealthy_threshold = 5
+    path                = "/api/v1/health"
+    matcher             = "200"
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-tg" })
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      status_code = "HTTP_301"
+      port        = "443"
+      protocol    = "HTTPS"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = aws_acm_certificate_validation.primary.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+resource "aws_appautoscaling_target" "ecs" {
+  max_capacity       = 6
+  min_capacity       = 2
+  resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.backend.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "${var.project}-${var.environment}-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = var.cpu_target_utilization
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    scale_in_cooldown  = 120
+    scale_out_cooldown = 60
+  }
+}
+
+resource "aws_appautoscaling_policy" "latency" {
+  name               = "${var.project}-${var.environment}-latency"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+
+  depends_on = [aws_cloudwatch_metric_alarm.alb_latency]
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_latency" {
+  alarm_name          = "${var.project}-${var.environment}-p90-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  threshold           = var.latency_target_ms
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  statistic           = "p90"
+  period              = 60
+  dimensions = {
+    LoadBalancer = aws_lb.this.arn_suffix
+  }
+}

--- a/infra/aws/prod/cloudfront.tf
+++ b/infra/aws/prod/cloudfront.tf
@@ -1,0 +1,81 @@
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.project}-${var.environment}-oac"
+  description                       = "OAC для CloudFront"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.project} ${var.environment} frontend"
+  default_root_object = "index.html"
+
+  aliases = [var.domain_name]
+
+  origin {
+    domain_name = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id   = "s3-frontend"
+
+    s3_origin_config {
+      origin_access_identity = null
+    }
+
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "s3-frontend"
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 60
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.primary.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  web_acl_id = aws_wafv2_web_acl.cloudfront.arn
+
+  depends_on = [aws_acm_certificate_validation.primary]
+
+  tags = local.tags
+}
+
+resource "aws_route53_record" "frontend" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    evaluate_target_health = false
+    name                   = aws_cloudfront_distribution.frontend.domain_name
+    zone_id                = aws_cloudfront_distribution.frontend.hosted_zone_id
+  }
+}

--- a/infra/aws/prod/ecr.tf
+++ b/infra/aws/prod/ecr.tf
@@ -1,0 +1,28 @@
+resource "aws_ecr_repository" "backend" {
+  name = "${var.project}/${var.environment}/backend"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  lifecycle_policy {
+    policy = jsonencode({
+      rules = [
+        {
+          rulePriority = 1
+          description  = "Keep last 10 images"
+          selection = {
+            tagStatus   = "any"
+            countType   = "imageCountMoreThan"
+            countNumber = 10
+          }
+          action = {
+            type = "expire"
+          }
+        }
+      ]
+    })
+  }
+
+  tags = local.tags
+}

--- a/infra/aws/prod/ecs.tf
+++ b/infra/aws/prod/ecs.tf
@@ -1,0 +1,102 @@
+resource "aws_ecs_cluster" "this" {
+  name = "${var.project}-${var.environment}"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_ecs_task_definition" "backend" {
+  family                   = local.backend_name
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = tostring(var.container_cpu)
+  memory                   = tostring(var.container_memory)
+  network_mode             = "awsvpc"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "backend"
+      image     = var.container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        { name = "AWS_REGION", value = var.aws_region },
+        { name = "S3_BUCKET", value = aws_s3_bucket.files.bucket },
+        { name = "CORS_ORIGINS", value = "https://${var.domain_name}" }
+      ]
+      secrets = [
+        { name = "DATABASE_URL", valueFrom = aws_ssm_parameter.database_url.arn },
+        { name = "SECRET_KEY", valueFrom = "${aws_secretsmanager_secret.backend_env.arn}:SECRET_KEY::" },
+        { name = "SENTRY_DSN", valueFrom = aws_secretsmanager_secret.sentry_backend.arn },
+        { name = "FEATURE_AI_INSIGHTS", valueFrom = "${aws_secretsmanager_secret.backend_env.arn}:FEATURE_AI_INSIGHTS::" },
+        { name = "OPENAI_API_KEY", valueFrom = aws_ssm_parameter.openai_api_key.arn }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs_backend.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:${var.container_port}/api/v1/health || exit 1"]
+        startPeriod = 30
+        interval    = 30
+        retries     = 3
+        timeout     = 5
+      }
+    }
+  ])
+
+  tags = local.tags
+}
+
+resource "aws_ecs_service" "backend" {
+  name            = local.backend_name
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+  platform_version = "1.4.0"
+
+  network_configuration {
+    assign_public_ip = false
+    subnets          = [for s in aws_subnet.private : s.id]
+    security_groups  = [aws_security_group.ecs.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.backend.arn
+    container_name   = "backend"
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  depends_on = [aws_lb_listener.https]
+
+  tags = local.tags
+}

--- a/infra/aws/prod/eventbridge.tf
+++ b/infra/aws/prod/eventbridge.tf
@@ -1,0 +1,115 @@
+locals {
+  hourly_jobs = ["sales", "pops", "anomalies"]
+  nightly_jobs = ["plan_vs_fact", "seasonality", "bonus_liability"]
+}
+
+resource "aws_iam_role" "eventbridge_invoke" {
+  name = "${var.project}-${var.environment}-eventbridge"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "events.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "eventbridge_invoke" {
+  role = aws_iam_role.eventbridge_invoke.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "ecs:RunTask"
+      Resource = aws_ecs_task_definition.backend.arn
+      Condition = {
+        ArnEquals = {
+          "ecs:cluster" = aws_ecs_cluster.this.arn
+        }
+      }
+    }, {
+      Effect   = "Allow"
+      Action   = ["iam:PassRole"]
+      Resource = [aws_iam_role.ecs_task_execution_role.arn, aws_iam_role.ecs_task_role.arn]
+    }]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "scheduled_tasks" {
+  name              = "/aws/events/${var.project}-${var.environment}-scheduled"
+  retention_in_days = var.log_retention_days
+  tags              = local.tags
+}
+
+resource "aws_cloudwatch_event_rule" "hourly" {
+  name                = "${var.project}-${var.environment}-hourly"
+  description         = "Ежечасные задания"
+  schedule_expression = "cron(0 * * * ? *)"
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_event_rule" "nightly" {
+  name                = "${var.project}-${var.environment}-nightly"
+  description         = "Ночные задания"
+  schedule_expression = "cron(0 2 * * ? *)"
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "hourly" {
+  for_each = toset(local.hourly_jobs)
+
+  rule      = aws_cloudwatch_event_rule.hourly.name
+  target_id = each.key
+  arn       = aws_ecs_cluster.this.arn
+  role_arn  = aws_iam_role.eventbridge_invoke.arn
+
+  ecs_target {
+    task_definition_arn = aws_ecs_task_definition.backend.arn
+    launch_type         = "FARGATE"
+    network_configuration {
+      subnets         = [for s in aws_subnet.private : s.id]
+      security_groups = [aws_security_group.ecs.id]
+    }
+    platform_version = "1.4.0"
+    task_count       = 1
+    propagate_tags   = "TASK_DEFINITION"
+  }
+
+  input = jsonencode({
+    detail-type = "scheduled-task"
+    source      = "eventbridge"
+    job         = each.key
+  })
+}
+
+resource "aws_cloudwatch_event_target" "nightly" {
+  for_each = toset(local.nightly_jobs)
+
+  rule      = aws_cloudwatch_event_rule.nightly.name
+  target_id = each.key
+  arn       = aws_ecs_cluster.this.arn
+  role_arn  = aws_iam_role.eventbridge_invoke.arn
+
+  ecs_target {
+    task_definition_arn = aws_ecs_task_definition.backend.arn
+    launch_type         = "FARGATE"
+    network_configuration {
+      subnets         = [for s in aws_subnet.private : s.id]
+      security_groups = [aws_security_group.ecs.id]
+    }
+    platform_version = "1.4.0"
+    task_count       = 1
+    propagate_tags   = "TASK_DEFINITION"
+  }
+
+  input = jsonencode({
+    detail-type = "scheduled-task"
+    source      = "eventbridge"
+    job         = each.key
+  })
+}

--- a/infra/aws/prod/iam.tf
+++ b/infra/aws/prod/iam.tf
@@ -1,0 +1,75 @@
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "${var.project}-${var.environment}-ecs-execution"
+
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "${var.project}-${var.environment}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "ecs_task_extra" {
+  name        = "${var.project}-${var.environment}-ecs-task-extra"
+  description = "Доступ к S3, Secrets Manager и Parameter Store"
+
+  policy = data.aws_iam_policy_document.ecs_task_extra.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_extra" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.ecs_task_extra.arn
+}
+
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "ecs_task_extra" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["${aws_s3_bucket.files.arn}/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue", "ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+    resources = [
+      aws_secretsmanager_secret.backend_env.arn,
+      aws_secretsmanager_secret.db_password.arn,
+      aws_secretsmanager_secret.sentry_backend.arn,
+      aws_secretsmanager_secret.sentry_frontend.arn,
+      aws_ssm_parameter.openai_api_key.arn,
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/oppo-kz/*"
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [
+      "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${local.backend_name}:*"
+    ]
+  }
+}
+
+data "aws_caller_identity" "current" {}

--- a/infra/aws/prod/locals.tf
+++ b/infra/aws/prod/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+
+  backend_name = "${var.project}-${var.environment}-backend"
+  frontend_id  = "${var.project}-${var.environment}-frontend"
+  files_bucket = "${var.project}-${var.environment}-files"
+}

--- a/infra/aws/prod/logging.tf
+++ b/infra/aws/prod/logging.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "ecs_backend" {
+  name              = "/ecs/${local.backend_name}"
+  retention_in_days = var.log_retention_days
+  tags              = local.tags
+}

--- a/infra/aws/prod/networking.tf
+++ b/infra/aws/prod/networking.tf
@@ -1,0 +1,124 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.tags, {
+    Name = "${var.project}-${var.environment}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  for_each = zipmap(range(length(var.public_subnet_cidrs)), var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = each.value
+  map_public_ip_on_launch = true
+  availability_zone       = element(data.aws_availability_zones.available.names, each.key)
+
+  tags = merge(local.tags, {
+    Name = "${var.project}-${var.environment}-public-${each.key}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = zipmap(range(length(var.private_subnet_cidrs)), var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value
+  availability_zone = element(data.aws_availability_zones.available.names, each.key)
+
+  tags = merge(local.tags, {
+    Name = "${var.project}-${var.environment}-private-${each.key}"
+    Tier = "private"
+  })
+}
+
+resource "aws_subnet" "database" {
+  for_each = zipmap(range(length(var.database_subnet_cidrs)), var.database_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value
+  availability_zone = element(data.aws_availability_zones.available.names, each.key)
+
+  tags = merge(local.tags, {
+    Name = "${var.project}-${var.environment}-db-${each.key}"
+    Tier = "database"
+  })
+}
+
+resource "aws_eip" "nat" {
+  for_each = aws_subnet.public
+
+  domain = "vpc"
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-nat-eip-${each.key}" })
+}
+
+resource "aws_nat_gateway" "this" {
+  for_each = aws_subnet.public
+
+  allocation_id = aws_eip.nat[each.key].id
+  subnet_id     = each.value.id
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-nat-${each.key}" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-public" })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  for_each = aws_nat_gateway.this
+
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-private-${each.key}" })
+}
+
+resource "aws_route" "private_internet" {
+  for_each = aws_nat_gateway.this
+
+  route_table_id         = aws_route_table.private[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = each.value.id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private[each.key].id
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.project}-${var.environment}-db-subnet"
+  subnet_ids = [for s in aws_subnet.database : s.id]
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-db-subnet" })
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/infra/aws/prod/outputs.tf
+++ b/infra/aws/prod/outputs.tf
@@ -1,0 +1,34 @@
+output "frontend_bucket" {
+  description = "Имя S3 бакета для фронтенда"
+  value       = aws_s3_bucket.frontend.bucket
+}
+
+output "files_bucket" {
+  description = "S3 бакет для загружаемых файлов"
+  value       = aws_s3_bucket.files.bucket
+}
+
+output "cloudfront_domain" {
+  description = "Домен CloudFront"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "alb_dns_name" {
+  description = "DNS ALB"
+  value       = aws_lb.this.dns_name
+}
+
+output "rds_endpoint" {
+  description = "Endpoint базы данных"
+  value       = aws_db_instance.postgres.address
+}
+
+output "ecs_cluster_name" {
+  description = "Имя ECS кластера"
+  value       = aws_ecs_cluster.this.name
+}
+
+output "ecr_repository_url" {
+  description = "URL ECR репозитория"
+  value       = aws_ecr_repository.backend.repository_url
+}

--- a/infra/aws/prod/rds.tf
+++ b/infra/aws/prod/rds.tf
@@ -1,0 +1,23 @@
+resource "aws_db_instance" "postgres" {
+  identifier              = "${var.project}-${var.environment}-pg"
+  engine                  = "postgres"
+  engine_version          = "15.4"
+  instance_class          = var.db_instance_class
+  allocated_storage       = var.db_allocated_storage
+  storage_type            = "gp3"
+  multi_az                = true
+  db_subnet_group_name    = aws_db_subnet_group.this.name
+  vpc_security_group_ids  = [aws_security_group.rds.id]
+  username                = var.db_username
+  password                = var.db_password
+  backup_retention_period = 14
+  delete_automated_backups = true
+  maintenance_window      = "Sun:00:00-Sun:03:00"
+  backup_window           = "03:00-06:00"
+  auto_minor_version_upgrade = true
+  publicly_accessible     = false
+  storage_encrypted       = true
+  deletion_protection     = true
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-pg" })
+}

--- a/infra/aws/prod/s3.tf
+++ b/infra/aws/prod/s3.tf
@@ -1,0 +1,107 @@
+resource "aws_s3_bucket" "frontend" {
+  bucket = local.frontend_id
+
+  tags = merge(local.tags, { Name = local.frontend_id })
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket     = aws_s3_bucket.frontend.id
+  policy     = data.aws_iam_policy_document.frontend_site.json
+  depends_on = [aws_cloudfront_distribution.frontend]
+}
+
+data "aws_iam_policy_document" "frontend_site" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "${aws_s3_bucket.frontend.arn}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.frontend.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "files" {
+  bucket        = local.files_bucket
+  force_destroy = false
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "cleanup-mpu"
+    enabled = true
+
+    abort_incomplete_multipart_upload_days = 7
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
+  tags = merge(local.tags, { Name = local.files_bucket })
+}
+
+resource "aws_s3_bucket_policy" "files" {
+  bucket = aws_s3_bucket.files.id
+  policy = data.aws_iam_policy_document.files_access.json
+}
+
+data "aws_iam_policy_document" "files_access" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.ecs_task_role.arn]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.files.arn}/*"
+    ]
+  }
+}

--- a/infra/aws/prod/secrets.tf
+++ b/infra/aws/prod/secrets.tf
@@ -1,0 +1,58 @@
+resource "aws_secretsmanager_secret" "db_password" {
+  name = "/${var.project}/${var.environment}/db_password"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id     = aws_secretsmanager_secret.db_password.id
+  secret_string = var.db_password
+}
+
+resource "aws_secretsmanager_secret" "sentry_backend" {
+  name = "/${var.project}/${var.environment}/sentry_backend_dsn"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "sentry_backend" {
+  secret_id     = aws_secretsmanager_secret.sentry_backend.id
+  secret_string = var.sentry_backend_dsn
+}
+
+resource "aws_secretsmanager_secret" "sentry_frontend" {
+  name = "/${var.project}/${var.environment}/sentry_frontend_dsn"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "sentry_frontend" {
+  secret_id     = aws_secretsmanager_secret.sentry_frontend.id
+  secret_string = var.sentry_frontend_dsn
+}
+
+resource "aws_secretsmanager_secret" "backend_env" {
+  name = "/${var.project}/${var.environment}/backend_env"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "backend_env" {
+  secret_id = aws_secretsmanager_secret.backend_env.id
+  secret_string = jsonencode({
+    SECRET_KEY           = "${var.project}-${var.environment}-secret"
+    FEATURE_AI_INSIGHTS  = lookup(var.feature_flags, "FEATURE_AI_INSIGHTS", "false")
+  })
+}
+
+resource "aws_ssm_parameter" "database_url" {
+  name        = "/${var.project}/${var.environment}/DATABASE_URL"
+  description = "Подключение к Postgres"
+  type        = "SecureString"
+  value       = "postgresql://${var.db_username}:${var.db_password}@${aws_db_instance.postgres.address}:5432/${var.project}"
+  tags        = local.tags
+}
+
+resource "aws_ssm_parameter" "openai_api_key" {
+  name        = var.openai_api_key_ssm_param
+  description = "Опциональный ключ OpenAI"
+  type        = "SecureString"
+  value       = ""
+  tags        = local.tags
+}

--- a/infra/aws/prod/security.tf
+++ b/infra/aws/prod/security.tf
@@ -1,0 +1,75 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.project}-${var.environment}-alb-sg"
+  description = "Доступ к ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidr_ingress
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidr_ingress
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-alb-sg" })
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.project}-${var.environment}-ecs-sg"
+  description = "Доступ задач ECS"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-ecs-sg" })
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.project}-${var.environment}-rds-sg"
+  description = "Доступ БД только из приватных подсетей"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "Postgres from ECS"
+    from_port        = 5432
+    to_port          = 5432
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-${var.environment}-rds-sg" })
+}

--- a/infra/aws/prod/variables.tf
+++ b/infra/aws/prod/variables.tf
@@ -1,0 +1,162 @@
+variable "project" {
+  description = "Имя проекта для тегирования ресурсов"
+  type        = string
+}
+
+variable "environment" {
+  description = "Имя окружения (prod/staging и т.д.)"
+  type        = string
+  default     = "prod"
+}
+
+variable "aws_region" {
+  description = "AWS регион для основного провайдера"
+  type        = string
+  default     = "me-central-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR блок для VPC"
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "Список CIDR блоков для публичных подсетей"
+  type        = list(string)
+  default     = [
+    "10.42.0.0/24",
+    "10.42.1.0/24"
+  ]
+}
+
+variable "private_subnet_cidrs" {
+  description = "Список CIDR блоков для приватных подсетей"
+  type        = list(string)
+  default     = [
+    "10.42.10.0/24",
+    "10.42.11.0/24"
+  ]
+}
+
+variable "database_subnet_cidrs" {
+  description = "CIDR блоки для выделенных подсетей БД"
+  type        = list(string)
+  default     = [
+    "10.42.20.0/24",
+    "10.42.21.0/24"
+  ]
+}
+
+variable "domain_name" {
+  description = "Полный домен фронтенда"
+  type        = string
+  default     = "app.oppo-kz.kz"
+}
+
+variable "hosted_zone_id" {
+  description = "ID существующей Route53 hosted zone"
+  type        = string
+}
+
+variable "container_image" {
+  description = "Docker образ backend"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Порт контейнера backend"
+  type        = number
+  default     = 8080
+}
+
+variable "desired_count" {
+  description = "Желаемое количество задач ECS"
+  type        = number
+  default     = 2
+}
+
+variable "sentry_backend_dsn" {
+  description = "Sentry DSN для backend"
+  type        = string
+  sensitive   = true
+}
+
+variable "sentry_frontend_dsn" {
+  description = "Sentry DSN для frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "allowed_cidr_ingress" {
+  description = "Список CIDR для доступа к ALB"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "db_username" {
+  description = "Имя пользователя Postgres"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Пароль Postgres"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_allocated_storage" {
+  description = "Размер хранилища RDS в ГБ"
+  type        = number
+  default     = 100
+}
+
+variable "db_instance_class" {
+  description = "Тип инстанса БД"
+  type        = string
+  default     = "db.m6gd.large"
+}
+
+variable "log_retention_days" {
+  description = "Срок хранения логов CloudWatch"
+  type        = number
+  default     = 30
+}
+
+variable "cpu_target_utilization" {
+  description = "Целевой уровень CPU для автоскейлинга"
+  type        = number
+  default     = 60
+}
+
+variable "latency_target_ms" {
+  description = "Порог P90 latency в мс для автоскейлинга"
+  type        = number
+  default     = 500
+}
+
+variable "container_cpu" {
+  description = "CPU для задачи Fargate"
+  type        = number
+  default     = 1024
+}
+
+variable "container_memory" {
+  description = "Память для задачи Fargate"
+  type        = number
+  default     = 2048
+}
+
+variable "feature_flags" {
+  description = "Карта feature-флагов для backend"
+  type        = map(string)
+  default     = {
+    FEATURE_AI_INSIGHTS = "false"
+  }
+}
+
+variable "openai_api_key_ssm_param" {
+  description = "Имя параметра SSM для OPENAI_API_KEY"
+  type        = string
+  default     = "/oppo-kz/prod/openai_api_key"
+}

--- a/infra/aws/prod/versions.tf
+++ b/infra/aws/prod/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.30"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}

--- a/infra/aws/prod/waf.tf
+++ b/infra/aws/prod/waf.tf
@@ -1,0 +1,130 @@
+resource "aws_wafv2_web_acl" "cloudfront" {
+  provider    = aws.us_east_1
+  name        = "${var.project}-${var.environment}-cf-waf"
+  description = "Базовая защита CloudFront"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project}-${var.environment}-cf-waf"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_wafv2_web_acl" "alb" {
+  name        = "${var.project}-${var.environment}-alb-waf"
+  description = "Базовая защита ALB"
+  scope       = "REGIONAL"
+  region      = var.aws_region
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project}-${var.environment}-alb-waf"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "sqli"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_wafv2_web_acl_association" "alb" {
+  resource_arn = aws_lb.this.arn
+  web_acl_arn  = aws_wafv2_web_acl.alb.arn
+}

--- a/scripts/bootstrap_aws_infra.sh
+++ b/scripts/bootstrap_aws_infra.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Скрипт подготовки AWS ресурсов до запуска Terraform/CI
+# Требует установленный aws cli и авторизацию с правами администратора.
+
+PROJECT="oppo-kz"
+ENVIRONMENT="prod"
+REGION="me-central-1"
+ACM_REGION="us-east-1"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws cli не найден" >&2
+  exit 1
+fi
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+
+# Создание ECR репозитория (если нет)
+REPO_NAME="${PROJECT}/${ENVIRONMENT}/backend"
+if ! aws ecr describe-repositories --repository-names "$REPO_NAME" --region "$REGION" >/dev/null 2>&1; then
+  aws ecr create-repository \
+    --repository-name "$REPO_NAME" \
+    --image-scanning-configuration scanOnPush=true \
+    --region "$REGION"
+  echo "Создан репозиторий ECR: $REPO_NAME"
+else
+  echo "ECR репозиторий уже существует: $REPO_NAME"
+fi
+
+# S3 для CI артефактов (опционально)
+ARTIFACT_BUCKET="${PROJECT}-${ENVIRONMENT}-artifacts"
+if ! aws s3api head-bucket --bucket "$ARTIFACT_BUCKET" >/dev/null 2>&1; then
+  aws s3api create-bucket --bucket "$ARTIFACT_BUCKET" --region "$REGION" --create-bucket-configuration LocationConstraint="$REGION"
+  aws s3api put-bucket-versioning --bucket "$ARTIFACT_BUCKET" --versioning-configuration Status=Enabled
+  echo "Создан бакет для артефактов: s3://$ARTIFACT_BUCKET"
+fi
+
+# Предварительный запрос ACM сертификата (в us-east-1 для CloudFront)
+CERT_ARN=$(aws acm list-certificates --region "$ACM_REGION" --query "CertificateSummaryList[?DomainName=='app.oppo-kz.kz'].CertificateArn" --output text)
+if [ -z "$CERT_ARN" ] || [ "$CERT_ARN" = "None" ]; then
+  CERT_ARN=$(aws acm request-certificate \
+    --region "$ACM_REGION" \
+    --domain-name "app.oppo-kz.kz" \
+    --validation-method DNS \
+    --idempotency-token "${PROJECT}${ENVIRONMENT}" \
+    --query CertificateArn --output text)
+  echo "Запрошен ACM сертификат: $CERT_ARN"
+else
+  echo "Найден существующий сертификат: $CERT_ARN"
+fi
+
+echo "Проверьте Route53 и добавьте записи CNAME для валидации сертификата."
+
+echo "Bootstrap завершён. Далее: terraform init/plan/apply в infra/aws/prod"


### PR DESCRIPTION
## Summary
- add Terraform stack for AWS production including VPC, ECS Fargate behind ALB, RDS, S3/CloudFront static hosting, WAF, EventBridge schedules, and secret management
- document environment variables, bootstrap steps, and update repo README to reflect AWS deployment flow
- implement backend and frontend GitHub Actions pipelines with reusable jobs, artefact caching, ECR deploy, Render staging trigger, and CloudFront invalidation

## Testing
- not run (configuration and infrastructure only)


------
https://chatgpt.com/codex/tasks/task_e_68e255b633cc832f8aa35a448447e70e