### PR TITLE
feat: add ai insights summarizer and widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 DATABASE_URL=postgresql+psycopg://user:pass@host:5432/oppo_kz
 SECRET_KEY=change_me_long_random
 CORS_ORIGINS=http://localhost:5173
+FEATURE_AI_INSIGHTS=false
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_BASE_URL=https://api.openai.com/v1
 
 # Frontend
 VITE_API_URL=http://localhost:8000
+VITE_FEATURE_AI_INSIGHTS=false

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -6,6 +6,7 @@ from .routes.invites import router as invites_router
 from .routes.sales_v2 import router as sales_router
 from .routes.periods import router as periods_router
 from .routes.plans import router as plans_router
+from .insights import router as insights_router
 
 api_router = APIRouter()
 api_router.include_router(health_router)
@@ -15,3 +16,4 @@ api_router.include_router(invites_router)
 api_router.include_router(sales_router)
 api_router.include_router(periods_router)
 api_router.include_router(plans_router)
+api_router.include_router(insights_router, prefix="/insights", tags=["insights"])

--- a/backend/app/api/v1/insights.py
+++ b/backend/app/api/v1/insights.py
@@ -1,0 +1,37 @@
+"""Маршруты AI-инсайтов."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.core.settings import settings
+from app.feature_flags.deps import check_feature
+from app.schemas.insights import InsightSummarizeRequest, InsightSummary
+from app.services.insights import InsightsService
+
+router = APIRouter()
+
+
+def get_insights_service() -> InsightsService:
+    """Возвращает сервис с текущими настройками."""
+
+    return InsightsService(settings)
+
+
+@router.post(
+    "/summarize",
+    response_model=InsightSummary,
+    dependencies=[Depends(check_feature("FEATURE_AI_INSIGHTS"))],
+    summary="Генерация AI-саммари по KPI",
+)
+async def summarize_insights(
+    body: InsightSummarizeRequest,
+    service: InsightsService = Depends(get_insights_service),
+) -> InsightSummary:
+    """Возвращает структурированный саммари и действия."""
+
+    return await service.summarize(body)
+
+
+__all__ = ["router"]
+

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     enable_messages: bool = False
     enable_imports: bool = False
     enable_analytics: bool = False
+    feature_ai_insights: bool = False
+
+    openai_api_key: str | None = None
+    openai_base_url: str = "https://api.openai.com/v1"
+    openai_model: str = "gpt-4o-mini"
 
     @field_validator("database_url", mode="before")
     @classmethod

--- a/backend/app/feature_flags/deps.py
+++ b/backend/app/feature_flags/deps.py
@@ -13,13 +13,17 @@ from app.feature_flags.flags import flags
 class FeatureDisabled(Exception):
     """Raised when a feature is disabled."""
 
+    def __init__(self, feature: str):
+        self.feature = feature
+        super().__init__(feature)
+
 
 def check_feature(name: str) -> Callable[[], None]:
     """Return FastAPI dependency checking a feature flag."""
 
     def dependency() -> None:
         if not getattr(flags, name, False):
-            raise FeatureDisabled
+            raise FeatureDisabled(name)
 
     return dependency
 

--- a/backend/app/feature_flags/flags.py
+++ b/backend/app/feature_flags/flags.py
@@ -27,6 +27,10 @@ class Flags:
     def ENABLE_ANALYTICS(self) -> bool:  # включение аналитики
         return settings.enable_analytics
 
+    @property
+    def FEATURE_AI_INSIGHTS(self) -> bool:  # включение AI-инсайтов
+        return settings.feature_ai_insights
+
 
 flags = Flags()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,8 +8,9 @@ from datetime import datetime, timedelta
 from typing import Generator, Optional
 import uuid
 
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from sqlalchemy import text, inspect
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
@@ -20,6 +21,7 @@ from app.core.security import get_password_hash
 from app.db.session import SessionLocal, engine
 from app.db.base_class import Base
 from app.models.user import User, UserStatus
+from app.feature_flags.deps import FeatureDisabled
 
 # -----------------------------------------------------------------------------
 # Конфигурация из ENV
@@ -301,6 +303,13 @@ def seed_admin(db: Session) -> None:
 # FastAPI
 # -----------------------------------------------------------------------------
 app = FastAPI(title=PROJECT_NAME)
+
+
+@app.exception_handler(FeatureDisabled)
+async def feature_disabled_handler(request: Request, exc: FeatureDisabled) -> JSONResponse:  # noqa: D401
+    """Возвращает 404 при обращении к выключенной фиче."""
+
+    return JSONResponse(status_code=404, content={"detail": "Feature disabled", "code": "feature_disabled"})
 
 # CORS
 origins = [o.strip() for o in CORS_ORIGINS.split(",") if o.strip()]

--- a/backend/app/schemas/insights.py
+++ b/backend/app/schemas/insights.py
@@ -1,0 +1,139 @@
+"""Схемы AI-инсайтов."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class InsightKPI(BaseModel):
+    """Основные показатели KPI для генерации инсайтов."""
+
+    name: str = Field(..., description="Название KPI, например 'Выручка'")
+    unit: str | None = Field(None, description="Единица измерения (₸, шт и т.д.)")
+    plan: float | None = Field(None, description="Плановое значение за период")
+    actual: float = Field(..., description="Фактическое значение за период")
+    delta: float | None = Field(None, description="Абсолютное отклонение факт-план")
+    delta_percent: float | None = Field(None, description="Отклонение в процентах")
+    wow_percent: float | None = Field(None, description="Дельта к предыдущей неделе")
+    mom_percent: float | None = Field(None, description="Дельта к предыдущему месяцу")
+    yoy_percent: float | None = Field(None, description="Дельта к прошлому году")
+
+
+class InsightPopulation(BaseModel):
+    """Сегмент/измерение, на котором сфокусированы изменения."""
+
+    name: str
+    value: float | None = None
+    delta_percent: float | None = None
+
+
+class InsightAnomaly(BaseModel):
+    """Описание аномалий, найденных алгоритмами."""
+
+    dimension: str = Field(..., description="Измерение, например сеть или регион")
+    metric: str = Field(..., description="Метрика, по которой зафиксирована аномалия")
+    severity: Literal["low", "medium", "high"] | None = Field(
+        None, description="Уровень критичности"
+    )
+    description: str = Field(..., description="Человекочитаемое описание")
+
+
+class InsightTopItem(BaseModel):
+    """Элемент в топ-списке ростов/падений."""
+
+    name: str
+    value: float | None = None
+    delta_percent: float | None = None
+
+
+class InsightTopSummary(BaseModel):
+    """Подборка лучших/худших изменений."""
+
+    drops: list[InsightTopItem] = Field(default_factory=list)
+    gains: list[InsightTopItem] = Field(default_factory=list)
+
+
+class InsightSummarizeRequest(BaseModel):
+    """Запрос на генерацию саммари по KPI."""
+
+    scope: str = Field(..., examples=["national", "network:Mechta"])
+    period: str = Field(..., description="Период в произвольном формате, напр. '2024-09'")
+    kpi: InsightKPI
+    pops: list[InsightPopulation] = Field(default_factory=list)
+    anomalies: list[InsightAnomaly] = Field(default_factory=list)
+    tops: InsightTopSummary = Field(default_factory=InsightTopSummary)
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "scope": "national",
+                "period": "2024-09",
+                "kpi": {
+                    "name": "Выручка",
+                    "unit": "₸",
+                    "plan": 5200000000,
+                    "actual": 4800000000,
+                    "wow_percent": -7.2,
+                    "mom_percent": -3.5,
+                },
+                "pops": [
+                    {"name": "Сеть A", "delta_percent": -12.0},
+                    {"name": "Регион Юг", "delta_percent": -8.1},
+                ],
+                "anomalies": [
+                    {
+                        "dimension": "Сеть A",
+                        "metric": "Выручка",
+                        "severity": "high",
+                        "description": "Падение продаж Reno 11 на 25%",
+                    }
+                ],
+                "tops": {
+                    "drops": [
+                        {"name": "Сеть A", "delta_percent": -12.0},
+                        {"name": "Сеть B", "delta_percent": -5.0},
+                    ],
+                    "gains": [
+                        {"name": "Сеть C", "delta_percent": 4.5},
+                    ],
+                },
+            }
+        }
+    }
+
+
+class InsightAction(BaseModel):
+    """Кнопка действия на фронтенде."""
+
+    label: str = Field(..., description="Текст кнопки")
+    action: str = Field(..., description="Идентификатор действия для фронтенда")
+
+
+class InsightSummary(BaseModel):
+    """Ответ AI-инсайтов."""
+
+    headline: str
+    bullets: list[str] = Field(default_factory=list)
+    actions: list[InsightAction] = Field(default_factory=list)
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "headline": "Выручка просела на 7.7% от плана в период 2024-09.",
+                "bullets": [
+                    "Факт 4.8 млрд ₸ против плана 5.2 млрд ₸ (-7.7%).",
+                    "Динамика: WoW −7.2%, MoM −3.5%.",
+                    "Главное падение: Сеть A (−12.0%), прирост: Сеть C (+4.5%).",
+                    "Аномалия: Сеть A — Падение продаж Reno 11 на 25%.",
+                ],
+                "actions": [
+                    {"label": "Создать задачу супервизору", "action": "create_supervisor_task"},
+                    {"label": "Открыть бонус-сетку", "action": "open_bonus_grid"},
+                    {"label": "Отфильтровать по SKU/сети", "action": "open_filters"},
+                ],
+            }
+        }
+    }
+

--- a/backend/app/services/insights.py
+++ b/backend/app/services/insights.py
@@ -1,0 +1,223 @@
+"""Сервис генерации AI-инсайтов."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+import httpx
+
+from app.core.settings import Settings
+from app.schemas.insights import (
+    InsightAction,
+    InsightAnomaly,
+    InsightPopulation,
+    InsightSummarizeRequest,
+    InsightSummary,
+    InsightTopItem,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_PROMPT = (
+    "You are a retail analytics assistant. Given strictly the JSON metrics below (plan vs actual, WoW/MoM/YoY deltas, "
+    "anomalies, top drops/gains), write a concise 2–4 sentence summary in Russian and propose 1–3 concrete actions. Do not "
+    "invent entities not present in input. Output JSON with fields: headline, bullets[], actions[]. <INPUT_JSON>"
+)
+
+
+@dataclass(slots=True)
+class _RuleBasedContext:
+    payload: InsightSummarizeRequest
+    plan_gap_pct: float | None
+    dominant_drop: InsightTopItem | None
+    dominant_gain: InsightTopItem | None
+
+
+class InsightsService:
+    """Инкапсулирует режимы rule-based и LLM."""
+
+    def __init__(self, settings: Settings):
+        self._settings = settings
+
+    async def summarize(self, payload: InsightSummarizeRequest) -> InsightSummary:
+        """Возвращает саммари по KPI."""
+
+        if self._settings.openai_api_key:
+            try:
+                return await self._summarize_with_llm(payload)
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.exception("LLM insights failed, fallback to rule-based: %s", exc)
+        return self._summarize_rule_based(payload)
+
+    # ------------------------------------------------------------------
+    # Rule-based
+    # ------------------------------------------------------------------
+    def _summarize_rule_based(self, payload: InsightSummarizeRequest) -> InsightSummary:
+        ctx = _RuleBasedContext(
+            payload=payload,
+            plan_gap_pct=self._calc_plan_gap_pct(payload),
+            dominant_drop=(payload.tops.drops[0] if payload.tops.drops else None),
+            dominant_gain=(payload.tops.gains[0] if payload.tops.gains else None),
+        )
+
+        headline = self._make_headline(ctx)
+        bullets = self._make_bullets(ctx)
+        actions = self._make_actions(ctx)
+
+        return InsightSummary(headline=headline, bullets=bullets, actions=actions)
+
+    def _calc_plan_gap_pct(self, payload: InsightSummarizeRequest) -> float | None:
+        plan = payload.kpi.plan
+        if plan in (None, 0):
+            return None
+        actual = payload.kpi.actual
+        if plan == 0:
+            return None
+        return ((actual - plan) / plan) * 100
+
+    def _make_headline(self, ctx: _RuleBasedContext) -> str:
+        name = ctx.payload.kpi.name
+        period = ctx.payload.period
+        gap = ctx.plan_gap_pct
+        if gap is not None and abs(gap) >= 2:
+            if gap < 0:
+                return f"{name} просел на {self._format_percent(abs(gap), signed=False)} от плана в период {period}."
+            return f"{name} перевыполнен на {self._format_percent(gap)} относительно плана за {period}."
+        trend = self._first_defined(
+            ctx.payload.kpi.delta_percent,
+            ctx.payload.kpi.wow_percent,
+            ctx.payload.kpi.mom_percent,
+            ctx.payload.kpi.yoy_percent,
+        )
+        if trend is not None:
+            sign = "растёт" if trend >= 0 else "снижается"
+            return f"{name} {sign} на {self._format_percent(abs(trend), signed=False)} за период {period}."
+        return f"{name}: ключевые наблюдения за {period}."
+
+    def _make_bullets(self, ctx: _RuleBasedContext) -> list[str]:
+        bullets: list[str] = []
+        kpi = ctx.payload.kpi
+        unit = kpi.unit or ""
+        if kpi.plan is not None:
+            plan_text = self._format_amount(kpi.plan, unit)
+            actual_text = self._format_amount(kpi.actual, unit)
+            gap_text = (
+                f" ({self._format_percent(ctx.plan_gap_pct)})"
+                if ctx.plan_gap_pct is not None
+                else ""
+            )
+            bullets.append(f"Факт {actual_text} против плана {plan_text}{gap_text}.")
+        else:
+            actual_text = self._format_amount(kpi.actual, unit)
+            bullets.append(f"Факт {actual_text} без заданного плана.")
+
+        trends: list[str] = []
+        if kpi.wow_percent is not None:
+            trends.append(f"WoW {self._format_percent(kpi.wow_percent)}")
+        if kpi.mom_percent is not None:
+            trends.append(f"MoM {self._format_percent(kpi.mom_percent)}")
+        if kpi.yoy_percent is not None:
+            trends.append(f"YoY {self._format_percent(kpi.yoy_percent)}")
+        if trends:
+            bullets.append(f"Динамика: {', '.join(trends)}.")
+
+        focus_segments = [
+            f"{pop.name} ({self._format_percent(pop.delta_percent)})"
+            for pop in ctx.payload.pops[:3]
+            if pop.delta_percent is not None
+        ]
+        if focus_segments:
+            bullets.append("Фокус сегменты: " + ", ".join(focus_segments) + ".")
+
+        if ctx.dominant_drop or ctx.dominant_gain:
+            if ctx.dominant_drop and ctx.dominant_drop.delta_percent is not None:
+                bullets.append(
+                    f"Главное падение: {ctx.dominant_drop.name} ({self._format_percent(ctx.dominant_drop.delta_percent)})."
+                )
+            if ctx.dominant_gain and ctx.dominant_gain.delta_percent is not None:
+                bullets.append(
+                    f"Прирост: {ctx.dominant_gain.name} ({self._format_percent(ctx.dominant_gain.delta_percent)})."
+                )
+
+        for anomaly in ctx.payload.anomalies[:2]:
+            bullets.append(
+                f"Аномалия: {anomaly.dimension} — {anomaly.description}."
+            )
+
+        return bullets
+
+    def _make_actions(self, ctx: _RuleBasedContext) -> list[InsightAction]:
+        return [
+            InsightAction(label="Создать задачу супервизору", action="create_supervisor_task"),
+            InsightAction(label="Открыть бонус-сетку", action="open_bonus_grid"),
+            InsightAction(label="Отфильтровать по SKU/сети", action="open_filters"),
+        ]
+
+    # ------------------------------------------------------------------
+    # LLM mode
+    # ------------------------------------------------------------------
+    async def _summarize_with_llm(self, payload: InsightSummarizeRequest) -> InsightSummary:
+        body = payload.model_dump(exclude_none=True)
+        prompt = _PROMPT.replace("<INPUT_JSON>", json.dumps(body, ensure_ascii=False))
+        headers = {
+            "Authorization": f"Bearer {self._settings.openai_api_key}",
+            "Content-Type": "application/json",
+        }
+        data = {
+            "model": self._settings.openai_model,
+            "temperature": 0.2,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {"role": "user", "content": prompt},
+            ],
+        }
+        async with httpx.AsyncClient(base_url=self._settings.openai_base_url.rstrip("/"), timeout=30.0) as client:
+            response = await client.post("/chat/completions", headers=headers, json=data)
+        response.raise_for_status()
+        payload_json = response.json()
+        try:
+            message = payload_json["choices"][0]["message"]["content"]
+            parsed = json.loads(message)
+        except (KeyError, ValueError, IndexError) as exc:  # noqa: PERF203
+            raise RuntimeError("Unexpected OpenAI response") from exc
+        return InsightSummary.model_validate(parsed)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _format_amount(self, value: float, unit: str | None) -> str:
+        scaled_value = value
+        suffix = ""
+        abs_value = abs(value)
+        if abs_value >= 1_000_000_000:
+            scaled_value = value / 1_000_000_000
+            suffix = " млрд"
+        elif abs_value >= 1_000_000:
+            scaled_value = value / 1_000_000
+            suffix = " млн"
+        formatted = f"{scaled_value:.1f}".rstrip("0").rstrip(".")
+        unit_part = f" {unit}" if unit else ""
+        return f"{formatted}{suffix}{unit_part}".strip()
+
+    def _format_percent(self, value: float | None, *, signed: bool = True) -> str:
+        if value is None:
+            return "0%"
+        magnitude = abs(value)
+        if not signed or magnitude == 0:
+            return f"{magnitude:.1f}%"
+        sign = "+" if value > 0 else ("-" if value < 0 else "")
+        return f"{sign}{magnitude:.1f}%"
+
+    def _first_defined(self, *values: float | None) -> float | None:
+        for value in values:
+            if value is None:
+                continue
+            return value
+        return None
+
+
+__all__ = ["InsightsService"]
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.30.6
 SQLAlchemy==2.0.34
 psycopg[binary]==3.2.9
 pydantic==2.8.2
+pydantic-settings==2.4.0
 passlib[bcrypt]==1.7.4
 bcrypt==3.2.2
 PyJWT==2.9.0

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -1,0 +1,70 @@
+"""Тесты эндпоинта AI-инсайтов."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.settings import settings
+from app.main import app
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "scope": "national",
+        "period": "2024-09",
+        "kpi": {
+            "name": "Выручка",
+            "unit": "₸",
+            "plan": 5200000000,
+            "actual": 4800000000,
+            "wow_percent": -7.2,
+            "mom_percent": -3.5,
+        },
+        "pops": [
+            {"name": "Сеть A", "delta_percent": -12.0},
+            {"name": "Регион Юг", "delta_percent": -8.1},
+        ],
+        "anomalies": [
+            {
+                "dimension": "Сеть A",
+                "metric": "Выручка",
+                "severity": "high",
+                "description": "Падение продаж Reno 11 на 25%",
+            }
+        ],
+        "tops": {
+            "drops": [
+                {"name": "Сеть A", "delta_percent": -12.0},
+                {"name": "Сеть B", "delta_percent": -5.0},
+            ],
+            "gains": [
+                {"name": "Сеть C", "delta_percent": 4.5},
+            ],
+        },
+    }
+
+
+def test_insights_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "feature_ai_insights", False)
+    client = TestClient(app)
+    response = client.post("/api/v1/insights/summarize", json=_payload())
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Feature disabled", "code": "feature_disabled"}
+
+
+def test_insights_rule_based(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "feature_ai_insights", True)
+    monkeypatch.setattr(settings, "openai_api_key", None)
+    client = TestClient(app)
+    response = client.post("/api/v1/insights/summarize", json=_payload())
+    assert response.status_code == 200
+    data = response.json()
+    assert data["headline"] == "Выручка просел на 7.7% от плана в период 2024-09."
+    assert any("Факт" in bullet for bullet in data["bullets"])
+    assert len(data["actions"]) == 3
+    assert {action["action"] for action in data["actions"]} == {
+        "create_supervisor_task",
+        "open_bonus_grid",
+        "open_filters",
+    }
+

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:8000
+VITE_FEATURE_AI_INSIGHTS=false

--- a/frontend/src/entities/insight/mock.ts
+++ b/frontend/src/entities/insight/mock.ts
@@ -1,0 +1,48 @@
+import { InsightSummarizeRequest, InsightSummary } from "./types";
+
+export const insightSampleRequest: InsightSummarizeRequest = {
+  scope: "national",
+  period: "2024-09",
+  kpi: {
+    name: "Выручка",
+    unit: "₸",
+    plan: 5_200_000_000,
+    actual: 4_800_000_000,
+    wow_percent: -7.2,
+    mom_percent: -3.5,
+  },
+  pops: [
+    { name: "Сеть A", delta_percent: -12 },
+    { name: "Регион Юг", delta_percent: -8.1 },
+  ],
+  anomalies: [
+    {
+      dimension: "Сеть A",
+      metric: "Выручка",
+      severity: "high",
+      description: "Падение продаж Reno 11 на 25%",
+    },
+  ],
+  tops: {
+    drops: [
+      { name: "Сеть A", delta_percent: -12 },
+      { name: "Сеть B", delta_percent: -5 },
+    ],
+    gains: [{ name: "Сеть C", delta_percent: 4.5 }],
+  },
+};
+
+export const insightSampleResponse: InsightSummary = {
+  headline: "Выручка просела на 7.7% от плана в период 2024-09.",
+  bullets: [
+    "Факт 4.8 млрд ₸ против плана 5.2 млрд ₸ (-7.7%).",
+    "Динамика: WoW −7.2%, MoM −3.5%.",
+    "Главное падение: Сеть A (−12.0%), прирост: Сеть C (+4.5%).",
+    "Аномалия: Сеть A — Падение продаж Reno 11 на 25%.",
+  ],
+  actions: [
+    { label: "Создать задачу супервизору", action: "create_supervisor_task" },
+    { label: "Открыть бонус-сетку", action: "open_bonus_grid" },
+    { label: "Отфильтровать по SKU/сети", action: "open_filters" },
+  ],
+};

--- a/frontend/src/entities/insight/types.ts
+++ b/frontend/src/entities/insight/types.ts
@@ -1,0 +1,55 @@
+export interface InsightKPI {
+  name: string;
+  unit?: string | null;
+  plan?: number | null;
+  actual: number;
+  delta?: number | null;
+  delta_percent?: number | null;
+  wow_percent?: number | null;
+  mom_percent?: number | null;
+  yoy_percent?: number | null;
+}
+
+export interface InsightPopulation {
+  name: string;
+  value?: number | null;
+  delta_percent?: number | null;
+}
+
+export interface InsightAnomaly {
+  dimension: string;
+  metric: string;
+  severity?: "low" | "medium" | "high" | null;
+  description: string;
+}
+
+export interface InsightTopItem {
+  name: string;
+  value?: number | null;
+  delta_percent?: number | null;
+}
+
+export interface InsightTopSummary {
+  drops?: InsightTopItem[];
+  gains?: InsightTopItem[];
+}
+
+export interface InsightSummarizeRequest {
+  scope: string;
+  period: string;
+  kpi: InsightKPI;
+  pops?: InsightPopulation[];
+  anomalies?: InsightAnomaly[];
+  tops?: InsightTopSummary;
+}
+
+export interface InsightAction {
+  label: string;
+  action: string;
+}
+
+export interface InsightSummary {
+  headline: string;
+  bullets: string[];
+  actions: InsightAction[];
+}

--- a/frontend/src/pages/office/analytics/index.tsx
+++ b/frontend/src/pages/office/analytics/index.tsx
@@ -11,6 +11,9 @@ import { SyncControl } from "../../../features/sync-control";
 import { salesMock } from "../../../entities/sale/mock";
 import { products } from "../../../entities/product/mock";
 import { plansMock } from "../../../entities/plan/mock";
+import { ActionableInsightsWidget } from "../../../widgets/ActionableInsights";
+import { insightSampleRequest } from "../../../entities/insight/mock";
+import { featureFlags } from "../../../shared/config/featureFlags";
 
 const tabs = [
   { id: "all", label: "Все продажи", icon: BarChart4 },
@@ -93,6 +96,7 @@ export function OfficeAnalyticsPage() {
       </div>
       <FilterBar products={products} onChange={setFilters} />
       <KpiCards items={kpis} />
+      {featureFlags.aiInsights && <ActionableInsightsWidget request={insightSampleRequest} />}
       <div className="flex flex-wrap gap-2">
         {tabs.map((tab) => (
           <button

--- a/frontend/src/shared/api/http.ts
+++ b/frontend/src/shared/api/http.ts
@@ -3,6 +3,7 @@ import axios, { AxiosError, AxiosRequestConfig } from "axios";
 import { addOutboxRecord } from "../lib/indexedDb";
 import { createId } from "../lib/createId";
 import { mockApi } from "./mock";
+import type { InsightSummarizeRequest } from "../../entities/insight/types";
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? "";
 const API_ENABLED = Boolean(BASE_URL);
@@ -83,6 +84,10 @@ export const api = {
   bonus: {
     schemes: () => (API_ENABLED ? http.get("/api/v1/bonus/schemes") : mockApi.bonus.schemes()),
     payouts: (params?: unknown) => (API_ENABLED ? http.get("/api/v1/bonus/payouts", { params }) : mockApi.bonus.payouts()),
+  },
+  insights: {
+    summarize: (body: InsightSummarizeRequest) =>
+      API_ENABLED ? http.post("/api/v1/insights/summarize", body) : mockApi.insights.summarize(),
   },
   analytics: {
     kpi: (params?: unknown) => (API_ENABLED ? http.get("/api/v1/analytics/kpi", { params }) : Promise.resolve({ data: [] })),

--- a/frontend/src/shared/api/mock.ts
+++ b/frontend/src/shared/api/mock.ts
@@ -2,6 +2,7 @@ import { bonusPayoutsMock, bonusSchemesMock } from "../../entities/bonus/mock";
 import { dictionariesMock } from "../../entities/dict/mock";
 import { plansMock } from "../../entities/plan/mock";
 import { salesMock } from "../../entities/sale/mock";
+import { insightSampleResponse } from "../../entities/insight/mock";
 import { getAllMockUsers } from "../../entities/user/mock";
 
 export const mockApi = {
@@ -24,5 +25,8 @@ export const mockApi = {
   bonus: {
     schemes: async () => ({ data: bonusSchemesMock }),
     payouts: async () => ({ data: bonusPayoutsMock }),
+  },
+  insights: {
+    summarize: async () => ({ data: insightSampleResponse }),
   },
 };

--- a/frontend/src/shared/config/featureFlags.ts
+++ b/frontend/src/shared/config/featureFlags.ts
@@ -1,0 +1,10 @@
+export const featureFlags = {
+  aiInsights:
+    String(import.meta.env.VITE_FEATURE_AI_INSIGHTS ?? "false").toLowerCase() === "true",
+} as const;
+
+export type FeatureFlags = typeof featureFlags;
+
+export function isFeatureEnabled<K extends keyof FeatureFlags>(flag: K): FeatureFlags[K] {
+  return featureFlags[flag];
+}

--- a/frontend/src/widgets/ActionableInsights/ActionableInsightsWidget.tsx
+++ b/frontend/src/widgets/ActionableInsights/ActionableInsightsWidget.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { Loader2, Sparkles } from "lucide-react";
+import { isAxiosError } from "axios";
+
+import { api } from "../../shared/api/http";
+import { featureFlags } from "../../shared/config/featureFlags";
+import type { InsightSummarizeRequest, InsightSummary } from "../../entities/insight/types";
+
+interface Props {
+  request: InsightSummarizeRequest;
+}
+
+export function ActionableInsightsWidget({ request }: Props) {
+  const [summary, setSummary] = useState<InsightSummary | null>(null);
+  const [loading, setLoading] = useState<boolean>(featureFlags.aiInsights);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!featureFlags.aiInsights) {
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    api.insights
+      .summarize(request)
+      .then((response) => {
+        if (cancelled) return;
+        setSummary(response.data as InsightSummary);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (isAxiosError(err)) {
+          const data = err.response?.data as { detail?: string; code?: string } | undefined;
+          if (data?.code === "feature_disabled") {
+            setError("Модуль AI-инсайтов отключён (feature flag).");
+          } else {
+            setError(data?.detail || err.message || "Не удалось получить инсайты");
+          }
+          return;
+        }
+        const generic = err instanceof Error ? err.message : null;
+        setError(generic || "Не удалось получить инсайты");
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [request]);
+
+  if (!featureFlags.aiInsights) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 text-slate-700">
+            <Sparkles className="h-5 w-5 text-amber-500" />
+            <h2 className="text-xl font-semibold">Что делать?</h2>
+          </div>
+          {summary?.headline && (
+            <p className="mt-2 text-sm text-slate-500">{summary.headline}</p>
+          )}
+        </div>
+        {loading && <Loader2 className="h-5 w-5 animate-spin text-slate-400" />}
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600">
+          {error}
+        </div>
+      )}
+
+      {!error && summary && summary.bullets.length > 0 && (
+        <ul className="mt-4 space-y-2 text-sm text-slate-600">
+          {summary.bullets.map((bullet, index) => (
+            <li key={index} className="flex gap-2">
+              <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-amber-500" />
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!error && summary && summary.actions.length > 0 && (
+        <div className="mt-6 flex flex-wrap gap-2">
+          {summary.actions.map((action) => (
+            <button
+              key={action.action}
+              type="button"
+              onClick={() => console.info("insight-action", action.action)}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-900 hover:bg-slate-900 hover:text-white"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/widgets/ActionableInsights/index.ts
+++ b/frontend/src/widgets/ActionableInsights/index.ts
@@ -1,0 +1,1 @@
+export { ActionableInsightsWidget } from "./ActionableInsightsWidget";


### PR DESCRIPTION
## Summary
- add feature flag, schemas, service, and FastAPI route for AI insights with rule-based fallback and OpenAI integration
- expose POST /api/v1/insights/summarize, provide DTO examples, and add pytest coverage for enabled/disabled flows
- wire Vite feature flag, shared API client, mock data, and "Что делать?" widget on the office analytics page

## Testing
- pytest tests/test_insights.py

## Deployment Plan
- deploy backend after installing new dependency `pydantic-settings==2.4.0`
- add env vars FEATURE_AI_INSIGHTS, OPENAI_API_KEY/OPENAI_MODEL/OPENAI_BASE_URL on backend; VITE_FEATURE_AI_INSIGHTS on frontend
- run database migrations as usual (none introduced)

## Checklist
- [x] Updated environment examples (.env) for new flags and OpenAI settings
- [x] Added backend/ frontend feature flag plumbing and documentation in code comments
- [x] Covered rule-based summarizer behaviour with automated tests
- [x] Manually verified frontend builds locally (widget hidden when flag disabled)


------
https://chatgpt.com/codex/tasks/task_e_68e280a76dc4832fa028143792244ec1