### PR TITLE
feat: seed demo dataset and add e2e coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,21 @@ cd backend && uvicorn app.main:app
 # Frontend
 cd frontend && npm install && npm run dev
 ```
+
+## Демо-сиды
+```bash
+PYTHONPATH=backend python backend/scripts/seed_demo_data.py --purge
+```
+
+- сиды создают регионы, сети, магазины, пользователей всех ролей, планы, продажи, бонусные схемы и закрытый период на август 2024.
+- исходные данные описаны в `ops/demo/demo_data.json`.
+
+## E2E (Playwright)
+
+```bash
+# Требуется запущенный backend с доступом к API (по умолчанию http://localhost:8000/api/v1)
+API_BASE_URL=http://localhost:8000/api/v1 npm run test:e2e
+```
+
+- глобальный setup автоматически пересоздаёт demo-данные через `backend/scripts/seed_demo_data.py`.
+- сценарии живут в `e2e/tests/scenarios.spec.ts`.

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -6,6 +6,9 @@ from .routes.invites import router as invites_router
 from .routes.sales_v2 import router as sales_router
 from .routes.periods import router as periods_router
 from .routes.plans import router as plans_router
+from .routes.products import router as products_router
+from .routes.bonus_schemes import router as bonus_router
+from .routes.analytics import router as analytics_router
 from .insights import router as insights_router
 
 api_router = APIRouter()
@@ -16,4 +19,7 @@ api_router.include_router(invites_router)
 api_router.include_router(sales_router)
 api_router.include_router(periods_router)
 api_router.include_router(plans_router)
+api_router.include_router(products_router)
+api_router.include_router(bonus_router)
+api_router.include_router(analytics_router)
 api_router.include_router(insights_router, prefix="/insights", tags=["insights"])

--- a/backend/app/api/v1/routes/analytics.py
+++ b/backend/app/api/v1/routes/analytics.py
@@ -1,0 +1,31 @@
+"""Analytics endpoints."""
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.authz import require_roles
+from app.core.security import get_db
+from app.models.user import UserRole
+from app.schemas.analytics import SalesPerformanceOut
+from app.services.analytics import SalesAnalyticsService
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+@router.get("/sales/summary", response_model=SalesPerformanceOut)
+def sales_summary(
+    as_of: date | None = Query(default=None),
+    db: Session = Depends(get_db),
+    _: object = Depends(require_roles([UserRole.admin, UserRole.office, UserRole.supervisor])),
+) -> SalesPerformanceOut:
+    """Возвращает агрегированные метрики продаж."""
+
+    service = SalesAnalyticsService(db)
+    result = service.compute(as_of or date.today())
+    return SalesPerformanceOut.model_validate(result)
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/routes/bonus_schemes.py
+++ b/backend/app/api/v1/routes/bonus_schemes.py
@@ -1,0 +1,89 @@
+"""Bonus scheme endpoints."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.authz import require_roles
+from app.core.security import get_db
+from app.models.bonus import BonusScheme, BonusSchemeStatus, BonusRule
+from app.models.user import User, UserRole
+from app.schemas.bonus_scheme import BonusSchemeCreate, BonusSchemeOut
+
+router = APIRouter(prefix="/bonus-schemes", tags=["bonus_schemes"])
+
+
+@router.get("", response_model=list[BonusSchemeOut])
+def list_bonus_schemes(
+    network_id: str | None = Query(default=None),
+    status_filter: BonusSchemeStatus | None = Query(default=None, alias="status"),
+    db: Session = Depends(get_db),
+) -> list[BonusScheme]:
+    """Список бонусных схем по сети."""
+
+    query = db.query(BonusScheme).order_by(BonusScheme.valid_from.desc())
+    if network_id:
+        query = query.filter(BonusScheme.network_id == network_id)
+    if status_filter:
+        query = query.filter(BonusScheme.status == status_filter)
+    return query.all()
+
+
+@router.post("", response_model=BonusSchemeOut, status_code=status.HTTP_201_CREATED)
+def create_bonus_scheme(
+    payload: BonusSchemeCreate,
+    db: Session = Depends(get_db),
+    current: User = Depends(require_roles([UserRole.admin])),
+) -> BonusScheme:
+    """Создать черновик бонусной схемы."""
+
+    if not payload.rules:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="At least one rule required")
+
+    scheme = BonusScheme(
+        network_id=payload.network_id,
+        valid_from=payload.valid_from,
+        valid_to=payload.valid_to,
+        status=BonusSchemeStatus.draft,
+    )
+    db.add(scheme)
+    db.flush()
+    for rule in payload.rules:
+        db.add(
+            BonusRule(
+                scheme_id=scheme.id,
+                selector_type=rule.selector_type,
+                selector_value=rule.selector_value,
+                amount=rule.amount,
+                conditions_json=rule.conditions,
+            )
+        )
+    db.commit()
+    db.refresh(scheme)
+    return scheme
+
+
+@router.post("/{scheme_id}/publish", response_model=BonusSchemeOut)
+def publish_bonus_scheme(
+    scheme_id: str,
+    db: Session = Depends(get_db),
+    current: User = Depends(require_roles([UserRole.admin])),
+) -> BonusScheme:
+    """Перевести бонусную схему в статус published."""
+
+    scheme = db.query(BonusScheme).filter(BonusScheme.id == scheme_id).first()
+    if not scheme:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bonus scheme not found")
+    if scheme.status == BonusSchemeStatus.published:
+        return scheme
+    scheme.status = BonusSchemeStatus.published
+    scheme.updated_at = datetime.now(timezone.utc)
+    db.add(scheme)
+    db.commit()
+    db.refresh(scheme)
+    return scheme
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/routes/products.py
+++ b/backend/app/api/v1/routes/products.py
@@ -1,0 +1,76 @@
+"""Product endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.authz import require_roles
+from app.core.security import get_db
+from app.models.product import Product, ProductStatus
+from app.models.user import User, UserRole
+from app.schemas.product import ProductOut, ProductUpdate
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+@router.get("", response_model=list[ProductOut])
+def list_products(
+    status_filter: ProductStatus | None = Query(default=None, alias="status"),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+) -> list[Product]:
+    """Список SKU с опциональной фильтрацией по статусу."""
+
+    query = db.query(Product)
+    if status_filter:
+        query = query.filter(Product.status == status_filter)
+    products = (
+        query.order_by(Product.name.asc()).offset(offset).limit(limit).all()
+    )
+    return products
+
+
+@router.get("/{product_id}", response_model=ProductOut)
+def get_product(product_id: str, db: Session = Depends(get_db)) -> Product:
+    """Получить SKU по идентификатору."""
+
+    product = db.get(Product, product_id)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+@router.patch("/{product_id}", response_model=ProductOut)
+def update_product(
+    product_id: str,
+    payload: ProductUpdate,
+    db: Session = Depends(get_db),
+    current: User = Depends(require_roles([UserRole.admin])),
+) -> Product:
+    """Обновить SKU (например, пометить как EOL)."""
+
+    product = db.get(Product, product_id)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+
+    data = payload.model_dump(exclude_unset=True, by_alias=False)
+    if not data:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No changes provided")
+
+    if "status" in data:
+        product.status = data["status"]
+    if "name" in data:
+        product.name = data["name"]
+    if "price" in data:
+        product.price = data["price"]
+    if "valid_to" in data:
+        product.valid_to = data["valid_to"]
+
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/routes/sales_v2.py
+++ b/backend/app/api/v1/routes/sales_v2.py
@@ -224,13 +224,26 @@ def create_correction(
     sale_id: str,
     payload: SaleCorrectionCreate,
     db: Session = Depends(get_db),
-    current: User = Depends(require_roles([UserRole.supervisor, UserRole.office, UserRole.admin])),
+    current: User = Depends(get_current_user),
 ) -> SaleCorrection:
-    sale = db.query(Sale).filter(Sale.id == sale_id).one_or_none()
+    role = UserRole(current.role)
+    if role not in {UserRole.promoter, UserRole.supervisor, UserRole.office, UserRole.admin}:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    sale = (
+        db.query(Sale)
+        .options(joinedload(Sale.store))
+        .filter(Sale.id == sale_id)
+        .one_or_none()
+    )
     if not sale:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sale not found")
     if not sale.locked_at:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Sale must be locked")
+    _ensure_sale_permissions(sale, current)
+    if role == UserRole.promoter and sale.promoter_id != current.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
     correction = SaleCorrection(
         sale_id=sale.id,
         created_by=current.id,

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,0 +1,57 @@
+"""Analytics API schemas."""
+from __future__ import annotations
+
+from datetime import date
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PeriodValue(BaseModel):
+    """Общие показатели периода."""
+
+    qty: int
+    revenue: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PeriodDelta(BaseModel):
+    """Дельта между периодами."""
+
+    current: PeriodValue | None
+    previous: PeriodValue | None
+    change_pct: Decimal | None
+
+
+class FactValue(BaseModel):
+    """Факт продаж: база + коррекции."""
+
+    base_qty: int
+    base_revenue: Decimal
+    correction_qty: int
+    correction_revenue: Decimal
+    fact_qty: int
+    fact_revenue: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SalesPerformanceOut(BaseModel):
+    """Ответ аналитики продаж."""
+
+    as_of: date
+    mtd: FactValue
+    mtd_lfl: PeriodDelta
+    wow: PeriodDelta
+    mom: PeriodDelta
+    yoy: PeriodDelta
+
+
+__all__ = [
+    "PeriodValue",
+    "PeriodDelta",
+    "FactValue",
+    "SalesPerformanceOut",
+]

--- a/backend/app/schemas/bonus_scheme.py
+++ b/backend/app/schemas/bonus_scheme.py
@@ -1,0 +1,64 @@
+"""Bonus scheme schemas."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.bonus import BonusSchemeStatus, BonusSelectorType
+
+
+class BonusRuleCreate(BaseModel):
+    """Правило бонусной схемы при создании."""
+
+    selector_type: BonusSelectorType
+    selector_value: str | None = Field(default=None, max_length=255)
+    amount: Decimal = Field(gt=0)
+    conditions: dict[str, Any] | None = None
+
+
+class BonusSchemeCreate(BaseModel):
+    """Создание бонусной схемы."""
+
+    network_id: str
+    valid_from: date
+    valid_to: date | None = None
+    rules: list[BonusRuleCreate]
+
+
+class BonusRuleOut(BaseModel):
+    """DTO правила бонусов."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    selector_type: BonusSelectorType
+    selector_value: str | None
+    amount: Decimal
+    conditions_json: dict[str, Any] | None
+
+
+class BonusSchemeOut(BaseModel):
+    """DTO бонусной схемы."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    network_id: str
+    valid_from: date
+    valid_to: date | None
+    status: BonusSchemeStatus
+    rules: list[BonusRuleOut]
+    created_at: datetime
+    updated_at: datetime
+
+
+__all__ = [
+    "BonusRuleCreate",
+    "BonusSchemeCreate",
+    "BonusRuleOut",
+    "BonusSchemeOut",
+]

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -1,0 +1,37 @@
+"""Product API schemas."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.product import ProductStatus
+
+
+class ProductOut(BaseModel):
+    """DTO продукта."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: str
+    sku: str
+    name: str | None
+    status: ProductStatus
+    price: Decimal | None
+    attrs_json: dict[str, Any] | None = Field(default=None, alias="attrs")
+    valid_from: datetime | None
+    valid_to: datetime | None
+
+
+class ProductUpdate(BaseModel):
+    """Патч SKU."""
+
+    status: ProductStatus | None = None
+    name: str | None = None
+    price: Decimal | None = Field(default=None, ge=0)
+    valid_to: datetime | None = None
+
+
+__all__ = ["ProductOut", "ProductUpdate"]

--- a/backend/app/services/analytics.py
+++ b/backend/app/services/analytics.py
@@ -1,0 +1,185 @@
+"""Analytics computations for BI widgets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.sale import Sale, SaleCorrection, SaleStatus
+
+
+@dataclass(slots=True)
+class RangeAggregates:
+    """Aggregated sales metrics for a period."""
+
+    base_qty: int
+    base_revenue: Decimal
+    correction_qty: int
+    correction_revenue: Decimal
+
+    @property
+    def fact_qty(self) -> int:
+        return self.base_qty + self.correction_qty
+
+    @property
+    def fact_revenue(self) -> Decimal:
+        return self.base_revenue + self.correction_revenue
+
+
+def _to_decimal(value: object | None) -> Decimal:
+    if value is None:
+        return Decimal(0)
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def month_add(value: date, offset: int) -> date:
+    month = value.month - 1 + offset
+    year = value.year + month // 12
+    month = month % 12 + 1
+    day = min(value.day, _monthrange(year, month))
+    return date(year, month, day)
+
+
+def month_start(value: date) -> date:
+    return value.replace(day=1)
+
+
+def month_end(value: date) -> date:
+    return month_add(month_start(value), 1) - timedelta(days=1)
+
+
+def _monthrange(year: int, month: int) -> int:
+    import calendar
+
+    return calendar.monthrange(year, month)[1]
+
+
+class SalesAnalyticsService:
+    """Сервис агрегирования продаж."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def _stores_in_range(self, start: date, end: date) -> list[str]:
+        stmt = (
+            select(Sale.store_id)
+            .where(
+                Sale.date >= start,
+                Sale.date <= end,
+                Sale.status == SaleStatus.active,
+            )
+            .distinct()
+        )
+        return list(self.session.execute(stmt).scalars())
+
+    def _aggregate(self, start: date, end: date, store_ids: Sequence[str] | None = None) -> RangeAggregates:
+        query = self.session.query(
+            func.coalesce(func.sum(Sale.qty), 0),
+            func.coalesce(func.sum(Sale.qty * func.coalesce(Sale.price, 0)), 0),
+        ).filter(Sale.date >= start, Sale.date <= end, Sale.status == SaleStatus.active)
+        if store_ids:
+            query = query.filter(Sale.store_id.in_(store_ids))
+        base_qty, base_revenue = query.one()
+
+        corr_query = (
+            self.session.query(
+                func.coalesce(func.sum(SaleCorrection.delta_qty), 0),
+                func.coalesce(func.sum(SaleCorrection.delta_price), 0),
+            )
+            .join(Sale, SaleCorrection.sale_id == Sale.id)
+            .filter(Sale.date >= start, Sale.date <= end)
+        )
+        if store_ids:
+            corr_query = corr_query.filter(Sale.store_id.in_(store_ids))
+        corr_qty, corr_revenue = corr_query.one()
+        return RangeAggregates(
+            base_qty=int(base_qty or 0),
+            base_revenue=_to_decimal(base_revenue),
+            correction_qty=int(corr_qty or 0),
+            correction_revenue=_to_decimal(corr_revenue),
+        )
+
+    def _period_value(self, agg: RangeAggregates) -> dict[str, Decimal | int]:
+        return {"qty": agg.fact_qty, "revenue": agg.fact_revenue}
+
+    def _delta(self, current: RangeAggregates | None, previous: RangeAggregates | None) -> tuple[dict[str, Decimal | int] | None, dict[str, Decimal | int] | None, Decimal | None]:
+        current_payload = self._period_value(current) if current else None
+        previous_payload = self._period_value(previous) if previous else None
+        change = None
+        if current_payload and previous_payload and previous_payload["revenue"]:
+            change = ((current_payload["revenue"] - previous_payload["revenue"]) / previous_payload["revenue"]) * Decimal(100)
+        return current_payload, previous_payload, change
+
+    def compute(self, as_of: date) -> dict[str, object]:
+        """Посчитать метрики на заданную дату."""
+
+        today = as_of
+        month_start_current = month_start(today)
+        mtd = self._aggregate(month_start_current, today)
+        stores = self._stores_in_range(month_start_current, today)
+
+        last_year_start = month_add(month_start_current, -12)
+        last_year_end = month_add(today, -12)
+        lfl = self._aggregate(last_year_start, last_year_end, stores) if stores else RangeAggregates(0, Decimal(0), 0, Decimal(0))
+
+        current_week_start = today - timedelta(days=today.weekday())
+        last_week_start = current_week_start - timedelta(days=7)
+        last_week_end = current_week_start - timedelta(days=1)
+        prev_week_start = last_week_start - timedelta(days=7)
+        prev_week_end = last_week_start - timedelta(days=1)
+        week_current = self._aggregate(last_week_start, last_week_end)
+        week_previous = self._aggregate(prev_week_start, prev_week_end)
+
+        prev_month_start = month_add(month_start_current, -1)
+        prev_month_end = month_end(prev_month_start)
+        two_months_ago_start = month_add(prev_month_start, -1)
+        two_months_ago_end = month_end(two_months_ago_start)
+        month_current = self._aggregate(prev_month_start, prev_month_end)
+        month_previous = self._aggregate(two_months_ago_start, two_months_ago_end)
+
+        prev_month_last_year_start = month_add(prev_month_start, -12)
+        prev_month_last_year_end = month_end(prev_month_last_year_start)
+        yoy_prev = self._aggregate(prev_month_last_year_start, prev_month_last_year_end)
+
+        current_payload, previous_payload, wow_change = self._delta(week_current, week_previous)
+        mom_current, mom_previous, mom_change = self._delta(month_current, month_previous)
+        yoy_current, yoy_previous, yoy_change = self._delta(month_current, yoy_prev)
+        lfl_current, lfl_previous, lfl_change = self._delta(mtd, lfl)
+
+        return {
+            "as_of": today,
+            "mtd": {
+                "base_qty": mtd.base_qty,
+                "base_revenue": mtd.base_revenue,
+                "correction_qty": mtd.correction_qty,
+                "correction_revenue": mtd.correction_revenue,
+                "fact_qty": mtd.fact_qty,
+                "fact_revenue": mtd.fact_revenue,
+            },
+            "mtd_lfl": {
+                "current": lfl_current,
+                "previous": lfl_previous,
+                "change_pct": lfl_change,
+            },
+            "wow": {
+                "current": current_payload,
+                "previous": previous_payload,
+                "change_pct": wow_change,
+            },
+            "mom": {
+                "current": mom_current,
+                "previous": mom_previous,
+                "change_pct": mom_change,
+            },
+            "yoy": {
+                "current": yoy_current,
+                "previous": yoy_previous,
+                "change_pct": yoy_change,
+            },
+        }

--- a/backend/scripts/seed_demo_data.py
+++ b/backend/scripts/seed_demo_data.py
@@ -1,0 +1,609 @@
+"""Seed deterministic demo data for OPPO KZ platform."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Iterable
+import calendar
+
+from sqlalchemy import delete, select, text
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.db.session import SessionLocal
+from app.models.bonus import BonusRule, BonusScheme, BonusSchemeStatus, BonusSelectorType
+from app.models.city import City
+from app.models.network import Network
+from app.models.period import ClosedPeriod, ClosedScope
+from app.models.plan import PlanPromoterMonth, PlanSource
+from app.models.product import Product, ProductStatus
+from app.models.region import Region
+from app.models.sale import Sale, SaleStatus
+from app.models.store import Store
+from app.models.user import User, UserRole, UserStatus
+
+DATA_PATH_DEFAULT = Path("ops/demo/demo_data.json")
+
+
+@dataclass(slots=True)
+class SeedConfig:
+    reference_date: date
+    password: str
+    payload: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Date helpers
+# ---------------------------------------------------------------------------
+
+def month_add(value: date, offset: int) -> date:
+    """Shift a date by `offset` months preserving the day when possible."""
+
+    month = value.month - 1 + offset
+    year = value.year + month // 12
+    month = month % 12 + 1
+    day = min(value.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def build_anchors(reference: date) -> dict[str, date]:
+    """Compute reusable anchor dates for seed specification."""
+
+    current_week_start = reference - timedelta(days=reference.weekday())
+    anchors = {
+        "reference_date": reference,
+        "today": reference,
+        "current_week_start": current_week_start,
+        "last_week_start": current_week_start - timedelta(days=7),
+        "two_weeks_ago_start": current_week_start - timedelta(days=14),
+    }
+    current_month_start = reference.replace(day=1)
+    anchors["current_month_start"] = current_month_start
+    anchors["previous_month_start"] = month_add(current_month_start, -1)
+    anchors["two_months_ago_start"] = month_add(current_month_start, -2)
+    anchors["current_month_start_last_year"] = month_add(current_month_start, -12)
+    anchors["previous_month_start_last_year"] = month_add(anchors["previous_month_start"], -12)
+    return anchors
+
+
+def resolve_date(spec: dict[str, Any] | None, anchors: dict[str, date]) -> date | None:
+    """Resolve a date spec of the form {"anchor": name, "offset_days": int}."""
+
+    if not spec:
+        return None
+    anchor_name = spec.get("anchor")
+    if not anchor_name:
+        raise ValueError("Date spec missing anchor")
+    if anchor_name not in anchors:
+        raise ValueError(f"Unknown anchor '{anchor_name}' in seed data")
+    offset = int(spec.get("offset_days", 0))
+    return anchors[anchor_name] + timedelta(days=offset)
+
+
+def to_timestamp(d: date | None) -> datetime | None:
+    """Convert date to UTC midnight timestamp."""
+
+    if d is None:
+        return None
+    return datetime.combine(d, time.min, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# CRUD helpers
+# ---------------------------------------------------------------------------
+
+def ensure_region(session: Session, *, region_id: str, name: str) -> Region:
+    region = session.get(Region, region_id)
+    if region:
+        region.name = name
+    else:
+        region = Region(id=region_id, name=name)
+        session.add(region)
+    return region
+
+
+def ensure_city(session: Session, *, city_id: str, region_id: str, name: str) -> City:
+    city = session.get(City, city_id)
+    if city:
+        city.name = name
+        city.region_id = region_id
+    else:
+        city = City(id=city_id, name=name, region_id=region_id)
+        session.add(city)
+    return city
+
+
+def ensure_network(session: Session, *, network_id: str, name: str) -> Network:
+    network = session.get(Network, network_id)
+    if network:
+        network.name = name
+    else:
+        network = Network(id=network_id, name=name)
+        session.add(network)
+    return network
+
+
+def ensure_store(
+    session: Session,
+    *,
+    store_id: str,
+    network_id: str,
+    region_id: str,
+    code: str,
+    name: str,
+    address: str | None = None,
+) -> Store:
+    store = session.get(Store, store_id)
+    if store:
+        store.network_id = network_id
+        store.region_id = region_id
+        store.code = code
+        store.name = name
+        store.address = address
+    else:
+        store = Store(
+            id=store_id,
+            network_id=network_id,
+            region_id=region_id,
+            code=code,
+            name=name,
+            address=address,
+            active=True,
+        )
+        session.add(store)
+    return store
+
+
+def ensure_product(
+    session: Session,
+    *,
+    product_id: str,
+    sku: str,
+    name: str,
+    status: str,
+    price: Decimal | None,
+    attrs: dict[str, Any] | None,
+    valid_from: date | None,
+    valid_to: date | None,
+) -> Product:
+    product = session.get(Product, product_id)
+    status_enum = ProductStatus(status)
+    if product:
+        product.sku = sku
+        product.name = name
+        product.status = status_enum
+        product.price = price
+        product.attrs_json = attrs
+        product.valid_from = to_timestamp(valid_from)
+        product.valid_to = to_timestamp(valid_to)
+    else:
+        product = Product(
+            id=product_id,
+            sku=sku,
+            name=name,
+            status=status_enum,
+            price=price,
+            attrs_json=attrs,
+            valid_from=to_timestamp(valid_from),
+            valid_to=to_timestamp(valid_to),
+        )
+        session.add(product)
+    return product
+
+
+def ensure_user(
+    session: Session,
+    *,
+    user_id: str,
+    email: str,
+    full_name: str,
+    role: str,
+    region_id: str | None,
+    password: str,
+) -> User:
+    hashed = get_password_hash(password)
+    role_enum = UserRole(role)
+    user = session.get(User, user_id)
+    if user:
+        user.email = email
+        user.full_name = full_name
+        user.role = role_enum
+        user.region_id = region_id
+        user.status = UserStatus.active
+        user.hashed_password = hashed
+    else:
+        user = User(
+            id=user_id,
+            email=email,
+            full_name=full_name,
+            role=role_enum,
+            region_id=region_id,
+            status=UserStatus.active,
+            hashed_password=hashed,
+        )
+        session.add(user)
+    return user
+
+
+def ensure_bonus_scheme(
+    session: Session,
+    *,
+    scheme_id: str,
+    network_id: str,
+    valid_from: date,
+    valid_to: date | None,
+    status: str,
+    rules: Iterable[dict[str, Any]],
+) -> BonusScheme:
+    scheme = session.get(BonusScheme, scheme_id)
+    status_enum = BonusSchemeStatus(status)
+    if scheme:
+        scheme.network_id = network_id
+        scheme.valid_from = valid_from
+        scheme.valid_to = valid_to
+        scheme.status = status_enum
+    else:
+        scheme = BonusScheme(
+            id=scheme_id,
+            network_id=network_id,
+            valid_from=valid_from,
+            valid_to=valid_to,
+            status=status_enum,
+        )
+        session.add(scheme)
+        session.flush()
+    session.execute(delete(BonusRule).where(BonusRule.scheme_id == scheme.id))
+    for rule in rules:
+        session.add(
+            BonusRule(
+                scheme_id=scheme.id,
+                selector_type=BonusSelectorType(rule["selector_type"]),
+                selector_value=rule.get("selector_value"),
+                amount=Decimal(str(rule["amount"])),
+                conditions_json=rule.get("conditions"),
+            )
+        )
+    return scheme
+
+
+def ensure_plan(
+    session: Session,
+    *,
+    period_ym: str,
+    promoter_id: str,
+    store_id: str | None,
+    target_units: int | None,
+    target_revenue: Decimal | None,
+    updated_by: str,
+) -> PlanPromoterMonth:
+    plan = (
+        session.execute(
+            select(PlanPromoterMonth)
+            .where(
+                PlanPromoterMonth.period_ym == period_ym,
+                PlanPromoterMonth.promoter_id == promoter_id,
+                PlanPromoterMonth.store_id == store_id,
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if plan:
+        plan.target_units = target_units
+        plan.target_revenue = target_revenue
+        plan.source = PlanSource.import_file
+        plan.version = max(plan.version, 1)
+        plan.updated_by = updated_by
+        plan.updated_at = datetime.now(timezone.utc)
+    else:
+        plan = PlanPromoterMonth(
+            period_ym=period_ym,
+            promoter_id=promoter_id,
+            store_id=store_id,
+            target_units=target_units,
+            target_revenue=target_revenue,
+            source=PlanSource.import_file,
+            updated_by=updated_by,
+        )
+        session.add(plan)
+    return plan
+
+
+def ensure_sale(
+    session: Session,
+    *,
+    sale_id: str,
+    promoter_id: str,
+    store_id: str,
+    sku_id: str,
+    qty: int,
+    price: Decimal,
+    sale_date: date,
+    locked: bool,
+) -> Sale:
+    sale = session.get(Sale, sale_id)
+    now = datetime.now(timezone.utc)
+    if sale:
+        sale.promoter_id = promoter_id
+        sale.store_id = store_id
+        sale.sku_id = sku_id
+        sale.qty = qty
+        sale.price = price
+        sale.date = sale_date
+        sale.status = SaleStatus.active
+        sale.locked_at = now if locked else None
+        sale.updated_at = now
+    else:
+        sale = Sale(
+            id=sale_id,
+            promoter_id=promoter_id,
+            store_id=store_id,
+            sku_id=sku_id,
+            qty=qty,
+            price=price,
+            date=sale_date,
+            status=SaleStatus.active,
+            version=1,
+            locked_at=now if locked else None,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(sale)
+    return sale
+
+
+def ensure_closed_period(
+    session: Session,
+    *,
+    period_id: str,
+    scope: ClosedScope,
+    scope_id: str | None,
+    from_date: date,
+    to_date: date,
+    created_by: str | None,
+) -> ClosedPeriod:
+    period = session.get(ClosedPeriod, period_id)
+    now = datetime.now(timezone.utc)
+    if period:
+        period.scope = scope
+        period.scope_id = scope_id
+        period.from_date = from_date
+        period.to_date = to_date
+        period.created_by = created_by
+    else:
+        period = ClosedPeriod(
+            id=period_id,
+            scope=scope,
+            scope_id=scope_id,
+            from_date=from_date,
+            to_date=to_date,
+            created_by=created_by,
+            created_at=now,
+        )
+        session.add(period)
+    return period
+
+
+# ---------------------------------------------------------------------------
+# Inventory helpers
+# ---------------------------------------------------------------------------
+
+def stock_table_exists(session: Session) -> bool:
+    row = session.execute(text("select to_regclass('public.stock_balances') is not null")).scalar()
+    return bool(row)
+
+
+def upsert_inventory(session: Session, items: list[dict[str, Any]]) -> None:
+    if not items or not stock_table_exists(session):
+        return
+    for store_id in {int(item["store_key_numeric"]) for item in items}:
+        session.execute(text("delete from stock_balances where store_id = :store_id"), {"store_id": store_id})
+    for item in items:
+        session.execute(
+            text(
+                """
+                insert into stock_balances (store_id, sku_id, on_hand, in_transit)
+                values (:store_id, :sku_id, :on_hand, :in_transit)
+                """
+            ),
+            {
+                "store_id": int(item["store_key_numeric"]),
+                "sku_id": int(item["sku_key_numeric"]),
+                "on_hand": float(item.get("on_hand", 0)),
+                "in_transit": float(item.get("in_transit", 0)),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Purge
+# ---------------------------------------------------------------------------
+
+def purge_existing(session: Session, data: dict[str, Any]) -> None:
+    sale_ids = [sale["id"] for sale in data.get("sales", [])]
+    if sale_ids:
+        session.execute(delete(Sale).where(Sale.id.in_(sale_ids)))
+    scheme_ids = [scheme["id"] for scheme in data.get("bonus_schemes", [])]
+    if scheme_ids:
+        session.execute(delete(BonusScheme).where(BonusScheme.id.in_(scheme_ids)))
+    plan_promoters = [item["promoter_key"] for item in data.get("plans", [])]
+    if plan_promoters:
+        session.execute(delete(PlanPromoterMonth).where(PlanPromoterMonth.promoter_id.in_(plan_promoters)))
+    user_ids = [user["id"] for user in data.get("users", [])]
+    if user_ids:
+        session.execute(delete(User).where(User.id.in_(user_ids)))
+    store_ids = [store["id"] for network in data.get("networks", []) for store in network.get("stores", [])]
+    if store_ids:
+        session.execute(delete(Store).where(Store.id.in_(store_ids)))
+    network_ids = [network["id"] for network in data.get("networks", [])]
+    if network_ids:
+        session.execute(delete(Network).where(Network.id.in_(network_ids)))
+    city_ids = [city["id"] for region in data.get("regions", []) for city in region.get("cities", [])]
+    if city_ids:
+        session.execute(delete(City).where(City.id.in_(city_ids)))
+    region_ids = [region["id"] for region in data.get("regions", [])]
+    if region_ids:
+        session.execute(delete(Region).where(Region.id.in_(region_ids)))
+    product_ids = [product["id"] for product in data.get("products", [])]
+    if product_ids:
+        session.execute(delete(Product).where(Product.id.in_(product_ids)))
+    period_ids = [period["id"] for period in data.get("closed_periods", [])]
+    if period_ids:
+        session.execute(delete(ClosedPeriod).where(ClosedPeriod.id.in_(period_ids)))
+
+
+# ---------------------------------------------------------------------------
+# Main seeding logic
+# ---------------------------------------------------------------------------
+
+def apply_seed(session: Session, config: SeedConfig) -> None:
+    data = config.payload
+    anchors = build_anchors(config.reference_date)
+
+    # Regions and cities
+    key_to_region = {region["key"]: region["id"] for region in data.get("regions", [])}
+    for region_data in data.get("regions", []):
+        region = ensure_region(session, region_id=region_data["id"], name=region_data["name"])
+        for city in region_data.get("cities", []):
+            ensure_city(session, city_id=city["id"], region_id=region.id, name=city["name"])
+
+    # Networks and stores
+    for network in data.get("networks", []):
+        ensure_network(session, network_id=network["id"], name=network["name"])
+        for store in network.get("stores", []):
+            ensure_store(
+                session,
+                store_id=store["id"],
+                network_id=network["id"],
+                region_id=key_to_region[store["region_key"]],
+                code=store["code"],
+                name=store["name"],
+                address=store.get("address"),
+            )
+
+    # Products
+    for product in data.get("products", []):
+        ensure_product(
+            session,
+            product_id=product["id"],
+            sku=product["sku"],
+            name=product["name"],
+            status=product["status"],
+            price=Decimal(str(product.get("price"))) if product.get("price") is not None else None,
+            attrs=product.get("attrs"),
+            valid_from=resolve_date(product.get("valid_from"), anchors),
+            valid_to=resolve_date(product.get("valid_to"), anchors),
+        )
+
+    # Users
+    for user in data.get("users", []):
+        region_id = key_to_region.get(user.get("region_key")) if user.get("region_key") else None
+        ensure_user(
+            session,
+            user_id=user["id"],
+            email=user["email"],
+            full_name=user["full_name"],
+            role=user["role"],
+            region_id=region_id,
+            password=config.password,
+        )
+
+    # Bonus schemes
+    for scheme in data.get("bonus_schemes", []):
+        ensure_bonus_scheme(
+            session,
+            scheme_id=scheme["id"],
+            network_id=next(n["id"] for n in data["networks"] if n["key"] == scheme["network_key"]),
+            valid_from=resolve_date(scheme.get("valid_from"), anchors) or config.reference_date,
+            valid_to=resolve_date(scheme.get("valid_to"), anchors),
+            status=scheme["status"],
+            rules=scheme.get("rules", []),
+        )
+
+    # Plans
+    promoter_ids = {user["key"]: user["id"] for user in data.get("users", [])}
+    store_ids = {store["key"]: store["id"] for network in data.get("networks", []) for store in network.get("stores", [])}
+    admin_id = promoter_ids.get("user_admin")
+    for plan in data.get("plans", []):
+        period_start = month_add(config.reference_date.replace(day=1), plan.get("period_offset_months", 0))
+        period_ym = period_start.strftime("%Y-%m")
+        ensure_plan(
+            session,
+            period_ym=period_ym,
+            promoter_id=promoter_ids[plan["promoter_key"]],
+            store_id=store_ids.get(plan.get("store_key")),
+            target_units=plan.get("target_units"),
+            target_revenue=Decimal(str(plan.get("target_revenue"))) if plan.get("target_revenue") is not None else None,
+            updated_by=admin_id or promoter_ids[plan["promoter_key"]],
+        )
+
+    # Sales
+    product_ids = {product["key"]: product["id"] for product in data.get("products", [])}
+    for sale in data.get("sales", []):
+        ensure_sale(
+            session,
+            sale_id=sale["id"],
+            promoter_id=promoter_ids[sale["promoter_key"]],
+            store_id=store_ids[sale["store_key"]],
+            sku_id=product_ids[sale["sku_key"]],
+            qty=int(sale["qty"]),
+            price=Decimal(str(sale["price"])),
+            sale_date=resolve_date(sale.get("date"), anchors) or config.reference_date,
+            locked=bool(sale.get("locked", False)),
+        )
+
+    # Closed periods (optional)
+    for period in data.get("closed_periods", []):
+        scope = ClosedScope(period["scope"])
+        scope_id = None
+        if period.get("scope_key"):
+            if scope == ClosedScope.region:
+                scope_id = key_to_region[period["scope_key"]]
+            elif scope == ClosedScope.store:
+                scope_id = store_ids[period["scope_key"]]
+        ensure_closed_period(
+            session,
+            period_id=period["id"],
+            scope=scope,
+            scope_id=scope_id,
+            from_date=resolve_date(period.get("from"), anchors) or config.reference_date,
+            to_date=resolve_date(period.get("to"), anchors) or config.reference_date,
+            created_by=admin_id,
+        )
+
+    # Inventory (legacy numeric ids)
+    upsert_inventory(session, data.get("inventory", []))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def load_config(path: Path) -> SeedConfig:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    reference = date.fromisoformat(payload["reference_date"])
+    return SeedConfig(reference_date=reference, password=payload["password"], payload=payload)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed demo data")
+    parser.add_argument("--data-path", type=Path, default=DATA_PATH_DEFAULT, help="Path to JSON dataset")
+    parser.add_argument("--purge", action="store_true", help="Remove existing seed rows before inserting")
+    args = parser.parse_args()
+
+    config = load_config(args.data_path)
+    with SessionLocal() as session:
+        if args.purge:
+            purge_existing(session, config.payload)
+            session.commit()
+        apply_seed(session, config)
+        session.commit()
+    print("Seed completed", config.reference_date.isoformat())
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,12 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+export default async function globalSetup(): Promise<void> {
+  const repoRoot = path.resolve(__dirname, "..");
+  const env = { ...process.env, PYTHONPATH: "backend" };
+  execSync("python backend/scripts/seed_demo_data.py --purge", {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env,
+  });
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+import path from "node:path";
+
+const baseURL = process.env.API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+export default defineConfig({
+  testDir: path.join(__dirname, "tests"),
+  globalSetup: path.join(__dirname, "global-setup.ts"),
+  fullyParallel: false,
+  use: {
+    baseURL,
+    extraHTTPHeaders: {
+      "content-type": "application/json",
+    },
+  },
+  reporter: [["list"]],
+});

--- a/e2e/support/demoData.ts
+++ b/e2e/support/demoData.ts
@@ -1,0 +1,263 @@
+import rawData from "../../ops/demo/demo_data.json";
+
+export type DemoData = typeof rawData;
+
+export interface RegionSeed {
+  key: string;
+  id: string;
+  name: string;
+}
+
+export interface StoreSeed {
+  key: string;
+  id: string;
+  name: string;
+  networkKey: string;
+  networkId: string;
+  regionId: string;
+}
+
+export interface UserSeed {
+  key: string;
+  id: string;
+  email: string;
+  fullName: string;
+  role: string;
+  regionId: string | null;
+}
+
+export interface ProductSeed {
+  key: string;
+  id: string;
+  sku: string;
+  name: string;
+}
+
+export interface SaleSeed {
+  key: string;
+  id: string;
+  promoterKey: string;
+  promoterId: string;
+  storeKey: string;
+  storeId: string;
+  skuKey: string;
+  skuId: string;
+  qty: number;
+  price: number;
+  date: Date;
+  locked: boolean;
+  tags: string[];
+}
+
+export interface CorrectionSeed {
+  saleId: string;
+  deltaQty: number;
+  deltaPrice: number;
+}
+
+const data: DemoData = rawData;
+
+function makeUTC(year: number, monthIndex: number, day: number): Date {
+  return new Date(Date.UTC(year, monthIndex, day));
+}
+
+function daysInMonth(year: number, monthIndex: number): number {
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+}
+
+function addMonths(value: Date, offset: number): Date {
+  const year = value.getUTCFullYear();
+  const month = value.getUTCMonth() + offset;
+  const targetYear = year + Math.floor(month / 12);
+  const targetMonth = ((month % 12) + 12) % 12;
+  const day = Math.min(value.getUTCDate(), daysInMonth(targetYear, targetMonth));
+  return makeUTC(targetYear, targetMonth, day);
+}
+
+function startOfMonth(value: Date): Date {
+  return makeUTC(value.getUTCFullYear(), value.getUTCMonth(), 1);
+}
+
+function startOfWeek(value: Date): Date {
+  const day = value.getUTCDay();
+  const delta = (day + 6) % 7; // monday = 0
+  return makeUTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate() - delta);
+}
+
+function addDays(value: Date, offset: number): Date {
+  return new Date(value.getTime() + offset * 86_400_000);
+}
+
+const referenceDate = makeUTC(
+  Number(data.reference_date.slice(0, 4)),
+  Number(data.reference_date.slice(5, 7)) - 1,
+  Number(data.reference_date.slice(8, 10)),
+);
+
+const anchors: Record<string, Date> = {
+  reference_date: referenceDate,
+  today: referenceDate,
+  current_week_start: startOfWeek(referenceDate),
+  last_week_start: addDays(startOfWeek(referenceDate), -7),
+  two_weeks_ago_start: addDays(startOfWeek(referenceDate), -14),
+  current_month_start: startOfMonth(referenceDate),
+  previous_month_start: addMonths(startOfMonth(referenceDate), -1),
+  two_months_ago_start: addMonths(startOfMonth(referenceDate), -2),
+  current_month_start_last_year: addMonths(startOfMonth(referenceDate), -12),
+  previous_month_start_last_year: addMonths(addMonths(startOfMonth(referenceDate), -1), -12),
+};
+
+function resolveDate(spec: { anchor?: string; offset_days?: number } | null | undefined): Date {
+  if (!spec || !spec.anchor) {
+    return new Date(referenceDate.getTime());
+  }
+  const anchor = anchors[spec.anchor];
+  if (!anchor) {
+    throw new Error(`Unknown anchor ${spec.anchor}`);
+  }
+  const offset = spec.offset_days ?? 0;
+  return addDays(anchor, offset);
+}
+
+const regions: RegionSeed[] = data.regions.map((region) => ({
+  key: region.key,
+  id: region.id,
+  name: region.name,
+}));
+
+const regionByKey = new Map(regions.map((region) => [region.key, region]));
+
+const networks = data.networks.map((network) => ({
+  key: network.key,
+  id: network.id,
+  name: network.name,
+}));
+
+const stores: StoreSeed[] = data.networks.flatMap((network) =>
+  network.stores.map((store) => ({
+    key: store.key,
+    id: store.id,
+    name: store.name,
+    networkKey: network.key,
+    networkId: network.id,
+    regionId: regionByKey.get(store.region_key)!.id,
+  })),
+);
+
+const storeByKey = new Map(stores.map((store) => [store.key, store]));
+
+const users: UserSeed[] = data.users.map((user) => ({
+  key: user.key,
+  id: user.id,
+  email: user.email,
+  fullName: user.full_name,
+  role: user.role,
+  regionId: user.region_key ? regionByKey.get(user.region_key)!.id : null,
+}));
+
+const userByKey = new Map(users.map((user) => [user.key, user]));
+
+const products: ProductSeed[] = data.products.map((product) => ({
+  key: product.key,
+  id: product.id,
+  sku: product.sku,
+  name: product.name,
+}));
+
+const productByKey = new Map(products.map((product) => [product.key, product]));
+
+const sales: SaleSeed[] = data.sales.map((sale) => ({
+  key: sale.key,
+  id: sale.id,
+  promoterKey: sale.promoter_key,
+  promoterId: userByKey.get(sale.promoter_key)!.id,
+  storeKey: sale.store_key,
+  storeId: storeByKey.get(sale.store_key)!.id,
+  skuKey: sale.sku_key,
+  skuId: productByKey.get(sale.sku_key)!.id,
+  qty: sale.qty,
+  price: sale.price,
+  date: resolveDate(sale.date),
+  locked: Boolean(sale.locked),
+  tags: sale.tags ?? [],
+}));
+
+export const password = data.password;
+export const demoReferenceDate = referenceDate;
+export const demoNetworks = networks;
+export const demoUsers = users;
+export const demoStores = stores;
+export const demoProducts = products;
+export const demoSales = sales;
+
+export function formatDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+export function createSaleState(): Map<string, SaleSeed> {
+  return new Map(demoSales.map((sale) => [sale.id, { ...sale }]));
+}
+
+export function findSaleByTag(tag: string): SaleSeed {
+  const found = demoSales.find((sale) => sale.tags.includes(tag));
+  if (!found) {
+    throw new Error(`Sale with tag ${tag} not found`);
+  }
+  return found;
+}
+
+export function getSaleByKey(key: string): SaleSeed {
+  const found = demoSales.find((sale) => sale.key === key);
+  if (!found) {
+    throw new Error(`Sale with key ${key} not found`);
+  }
+  return found;
+}
+
+export function getNetworkId(key: string): string {
+  const found = demoNetworks.find((network) => network.key === key);
+  if (!found) {
+    throw new Error(`Network ${key} not found`);
+  }
+  return found.id;
+}
+
+export function getUserByKey(key: string): UserSeed {
+  const user = userByKey.get(key);
+  if (!user) {
+    throw new Error(`User ${key} not found`);
+  }
+  return user;
+}
+
+export function getStoreByKey(key: string): StoreSeed {
+  const store = storeByKey.get(key);
+  if (!store) {
+    throw new Error(`Store ${key} not found`);
+  }
+  return store;
+}
+
+export function getProductByKey(key: string): ProductSeed {
+  const product = productByKey.get(key);
+  if (!product) {
+    throw new Error(`Product ${key} not found`);
+  }
+  return product;
+}
+
+export function startOfWeekUtc(value: Date): Date {
+  return startOfWeek(value);
+}
+
+export function startOfMonthUtc(value: Date): Date {
+  return startOfMonth(value);
+}
+
+export function addMonthsUtc(value: Date, offset: number): Date {
+  return addMonths(value, offset);
+}
+
+export function addDaysUtc(value: Date, offset: number): Date {
+  return addDays(value, offset);
+}

--- a/e2e/tests/scenarios.spec.ts
+++ b/e2e/tests/scenarios.spec.ts
@@ -1,0 +1,414 @@
+import { test, expect } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import crypto from "node:crypto";
+
+import {
+  password,
+  demoReferenceDate,
+  createSaleState,
+  findSaleByTag,
+  getSaleByKey,
+  getNetworkId,
+  getUserByKey,
+  getStoreByKey,
+  getProductByKey,
+  formatDate,
+  addMonthsUtc,
+  addDaysUtc,
+  startOfMonthUtc,
+  startOfWeekUtc,
+} from "../support/demoData";
+
+interface RangeMetrics {
+  baseQty: number;
+  baseRevenue: number;
+  correctionQty: number;
+  correctionRevenue: number;
+  factQty: number;
+  factRevenue: number;
+}
+
+interface PeriodSummary {
+  current: RangeMetrics;
+  previous: RangeMetrics;
+  changePct: number | null;
+}
+
+const saleState = createSaleState();
+const corrections: { saleId: string; deltaQty: number; deltaPrice: number }[] = [];
+
+function toNumber(value: unknown): number {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return Number(value);
+  }
+  throw new Error(`Unexpected numeric value: ${String(value)}`);
+}
+
+function isWithin(date: Date, start: Date, end: Date): boolean {
+  return date.getTime() >= start.getTime() && date.getTime() <= end.getTime();
+}
+
+function aggregateRange(start: Date, end: Date, storeFilter?: Set<string>): RangeMetrics {
+  let baseQty = 0;
+  let baseRevenue = 0;
+  let correctionQty = 0;
+  let correctionRevenue = 0;
+  for (const sale of saleState.values()) {
+    if (isWithin(sale.date, start, end) && (!storeFilter || storeFilter.has(sale.storeKey))) {
+      baseQty += sale.qty;
+      baseRevenue += sale.qty * sale.price;
+    }
+  }
+  for (const correction of corrections) {
+    const sale = saleState.get(correction.saleId);
+    if (!sale) continue;
+    if (isWithin(sale.date, start, end) && (!storeFilter || storeFilter.has(sale.storeKey))) {
+      correctionQty += correction.deltaQty;
+      correctionRevenue += correction.deltaPrice;
+    }
+  }
+  return {
+    baseQty,
+    baseRevenue,
+    correctionQty,
+    correctionRevenue,
+    factQty: baseQty + correctionQty,
+    factRevenue: baseRevenue + correctionRevenue,
+  };
+}
+
+function toPeriodValue(metrics: RangeMetrics): RangeMetrics {
+  return { ...metrics };
+}
+
+function percentageChange(current: RangeMetrics, previous: RangeMetrics): number | null {
+  if (previous.factRevenue === 0) {
+    return null;
+  }
+  return ((current.factRevenue - previous.factRevenue) / previous.factRevenue) * 100;
+}
+
+function computeExpected(asOf: Date): { mtd: RangeMetrics; mtdLfl: PeriodSummary; wow: PeriodSummary; mom: PeriodSummary; yoy: PeriodSummary } {
+  const monthStart = startOfMonthUtc(asOf);
+  const mtd = aggregateRange(monthStart, asOf);
+
+  const currentStoreIds = new Set<string>();
+  for (const sale of saleState.values()) {
+    if (isWithin(sale.date, monthStart, asOf)) {
+      currentStoreIds.add(sale.storeKey);
+    }
+  }
+
+  const lflStart = addMonthsUtc(monthStart, -12);
+  const lflEnd = addMonthsUtc(asOf, -12);
+  const lfl = aggregateRange(lflStart, lflEnd, currentStoreIds);
+
+  const currentWeekStart = startOfWeekUtc(asOf);
+  const lastWeekStart = addDaysUtc(currentWeekStart, -7);
+  const lastWeekEnd = addDaysUtc(currentWeekStart, -1);
+  const prevWeekStart = addDaysUtc(lastWeekStart, -7);
+  const prevWeekEnd = addDaysUtc(lastWeekStart, -1);
+  const weekCurrent = aggregateRange(lastWeekStart, lastWeekEnd);
+  const weekPrevious = aggregateRange(prevWeekStart, prevWeekEnd);
+
+  const prevMonthStart = addMonthsUtc(monthStart, -1);
+  const prevMonthEnd = addDaysUtc(monthStart, -1);
+  const twoMonthsAgoStart = addMonthsUtc(prevMonthStart, -1);
+  const twoMonthsAgoEnd = addDaysUtc(prevMonthStart, -1);
+  const monthCurrent = aggregateRange(prevMonthStart, prevMonthEnd);
+  const monthPrevious = aggregateRange(twoMonthsAgoStart, twoMonthsAgoEnd);
+
+  const prevMonthLastYearStart = addMonthsUtc(prevMonthStart, -12);
+  const prevMonthLastYearEnd = addDaysUtc(addMonthsUtc(prevMonthLastYearStart, 1), -1);
+  const yoyPrevious = aggregateRange(prevMonthLastYearStart, prevMonthLastYearEnd);
+
+  return {
+    mtd,
+    mtdLfl: {
+      current: toPeriodValue(mtd),
+      previous: toPeriodValue(lfl),
+      changePct: percentageChange(mtd, lfl),
+    },
+    wow: {
+      current: toPeriodValue(weekCurrent),
+      previous: toPeriodValue(weekPrevious),
+      changePct: percentageChange(weekCurrent, weekPrevious),
+    },
+    mom: {
+      current: toPeriodValue(monthCurrent),
+      previous: toPeriodValue(monthPrevious),
+      changePct: percentageChange(monthCurrent, monthPrevious),
+    },
+    yoy: {
+      current: toPeriodValue(monthCurrent),
+      previous: toPeriodValue(yoyPrevious),
+      changePct: percentageChange(monthCurrent, yoyPrevious),
+    },
+  };
+}
+
+async function loginAs(request: APIRequestContext, email: string): Promise<{ headers: Record<string, string>; token: string }> {
+  const response = await request.post("/auth/login", {
+    data: { username: email, password },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = await response.json();
+  const token = body.access_token as string;
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    token,
+  };
+}
+
+function decimalCloseTo(actual: unknown, expected: number, precision = 6) {
+  expect(toNumber(actual)).toBeCloseTo(expected, precision);
+}
+
+function expectChange(actual: unknown, expected: number | null) {
+  if (expected === null) {
+    expect(actual).toBeNull();
+  } else {
+    decimalCloseTo(actual, expected, 6);
+  }
+}
+
+test.describe.serial("Business scenarios", () => {
+  test("Admin manages bonus schemes and product lifecycle", async ({ request }) => {
+    const admin = getUserByKey("user_admin");
+    const { headers: adminHeaders } = await loginAs(request, admin.email);
+    const technodomId = getNetworkId("network_technodom");
+    const nextMonthStart = addMonthsUtc(startOfMonthUtc(demoReferenceDate), 1);
+
+    const createResp = await request.post("/bonus-schemes", {
+      headers: adminHeaders,
+      data: {
+        network_id: technodomId,
+        valid_from: formatDate(nextMonthStart),
+        valid_to: null,
+        rules: [
+          { selector_type: "series", selector_value: "Reno", amount: 20000 },
+        ],
+      },
+    });
+    expect(createResp.status()).toBe(201);
+    const createdScheme = await createResp.json();
+    expect(createdScheme.status).toBe("draft");
+    const schemeId = createdScheme.id as string;
+
+    const publishResp = await request.post(`/bonus-schemes/${schemeId}/publish`, {
+      headers: adminHeaders,
+    });
+    expect(publishResp.ok()).toBeTruthy();
+    const published = await publishResp.json();
+    expect(published.status).toBe("published");
+
+    const product = getProductByKey("product_reno10");
+    const patchResp = await request.patch(`/products/${product.id}`, {
+      headers: adminHeaders,
+      data: { status: "eol" },
+    });
+    expect(patchResp.ok()).toBeTruthy();
+    const patched = await patchResp.json();
+    expect(patched.status).toBe("eol");
+  });
+
+  test("Office bulk plans and closing period locks edits", async ({ request }) => {
+    const officeUser = getUserByKey("user_office");
+    const { headers: officeHeaders } = await loginAs(request, officeUser.email);
+
+    const periodYm = `${demoReferenceDate.getUTCFullYear()}-${String(demoReferenceDate.getUTCMonth() + 1).padStart(2, "0")}`;
+    const planResp = await request.post("/plans/promoter-month/bulk", {
+      headers: officeHeaders,
+      data: [
+        {
+          period_ym: periodYm,
+          promoter_id: getUserByKey("user_promoter_aidos").id,
+          store_id: getStoreByKey("store_technodom_mega").id,
+          target_units: 50,
+          target_revenue: 9000000,
+          source: "import",
+          reason: "September revision",
+        },
+        {
+          period_ym: periodYm,
+          promoter_id: getUserByKey("user_promoter_assel").id,
+          store_id: getStoreByKey("store_sulpak_dostyk").id,
+          target_units: 32,
+          target_revenue: 5200000,
+          source: "import",
+          reason: "September revision",
+        },
+      ],
+    });
+    expect(planResp.status()).toBe(201);
+
+    const prevMonthStart = addMonthsUtc(startOfMonthUtc(demoReferenceDate), -1);
+    const prevMonthEnd = addDaysUtc(startOfMonthUtc(demoReferenceDate), -1);
+    const region = getUserByKey("user_supervisor_almaty").regionId!;
+    const closeResp = await request.post("/periods/close", {
+      headers: officeHeaders,
+      data: {
+        from_date: formatDate(prevMonthStart),
+        to_date: formatDate(prevMonthEnd),
+        scope: "region",
+        scope_id: region,
+      },
+    });
+    expect(closeResp.status()).toBe(201);
+
+    const lockedSale = findSaleByTag("promoter_lock_target");
+    const promoterId = lockedSale.promoterId;
+    const salesListResp = await request.get(`/sales?promoter_id=${promoterId}`, {
+      headers: officeHeaders,
+    });
+    expect(salesListResp.ok()).toBeTruthy();
+    const salesList = await salesListResp.json();
+    const targetSale = (salesList.items as any[]).find((item) => item.id === lockedSale.id);
+    expect(targetSale).toBeTruthy();
+
+    const editResp = await request.patch(`/sales/${lockedSale.id}`, {
+      headers: { ...officeHeaders, "If-Match": String(targetSale.version) },
+      data: { qty: targetSale.qty + 1 },
+    });
+    expect(editResp.status()).toBe(409);
+    const detail = await editResp.json();
+    expect(detail.detail.code ?? detail.detail?.code ?? detail.detail).toContain("locked");
+  });
+
+  test("Supervisor invites promoter and updates sale", async ({ request }) => {
+    const supervisor = getUserByKey("user_supervisor_almaty");
+    const { headers: supervisorHeaders } = await loginAs(request, supervisor.email);
+
+    const inviteResp = await request.post("/invites", {
+      headers: supervisorHeaders,
+      data: {
+        email: "new.promoter@oppo.kz",
+        role_requested: "promoter",
+      },
+    });
+    expect(inviteResp.status()).toBe(201);
+
+    const editableSale = getSaleByKey("sale_open_current");
+    const promoterId = editableSale.promoterId;
+    const salesResp = await request.get(`/sales?promoter_id=${promoterId}`, { headers: supervisorHeaders });
+    expect(salesResp.ok()).toBeTruthy();
+    const salesData = await salesResp.json();
+    const sale = (salesData.items as any[]).find((item) => item.id === editableSale.id);
+    expect(sale).toBeTruthy();
+
+    const updatedQty = sale.qty + 1;
+    const patchResp = await request.patch(`/sales/${editableSale.id}`, {
+      headers: { ...supervisorHeaders, "If-Match": String(sale.version) },
+      data: { qty: updatedQty, reason: "Stock recount" },
+    });
+    expect(patchResp.ok()).toBeTruthy();
+    const patchedSale = await patchResp.json();
+    expect(Number(patchedSale.qty)).toBe(updatedQty);
+    const saleEntry = saleState.get(editableSale.id)!;
+    saleEntry.qty = updatedQty;
+  });
+
+  test("Promoter syncs offline sale and submits correction", async ({ request }) => {
+    const promoter = getUserByKey("user_promoter_assel");
+    const { headers: promoterHeaders } = await loginAs(request, promoter.email);
+
+    const offlineSaleId = crypto.randomUUID();
+    const store = getStoreByKey("store_sulpak_dostyk");
+    const sku = getProductByKey("product_reno10");
+    const saleDate = addDaysUtc(demoReferenceDate, -5);
+    const offlineQty = 2;
+    const offlinePrice = 259990;
+    const createResp = await request.post("/sales", {
+      headers: promoterHeaders,
+      data: {
+        sale_id: offlineSaleId,
+        date: formatDate(saleDate),
+        store_id: store.id,
+        sku_id: sku.id,
+        qty: offlineQty,
+        price: offlinePrice,
+      },
+    });
+    expect(createResp.status()).toBe(201);
+    const created = await createResp.json();
+    expect(created.locked).toBeFalsy();
+    saleState.set(offlineSaleId, {
+      key: "offline_add",
+      id: offlineSaleId,
+      promoterKey: promoter.key,
+      promoterId: promoter.id,
+      storeKey: store.key,
+      storeId: store.id,
+      skuKey: sku.key,
+      skuId: sku.id,
+      qty: offlineQty,
+      price: offlinePrice,
+      date: saleDate,
+      locked: false,
+      tags: ["mtd"],
+    });
+
+    const lockedSale = findSaleByTag("promoter_lock_target");
+    const salesResp = await request.get(`/sales?promoter_id=${promoter.id}`, { headers: promoterHeaders });
+    expect(salesResp.ok()).toBeTruthy();
+    const salesData = await salesResp.json();
+    const locked = (salesData.items as any[]).find((item) => item.id === lockedSale.id);
+    expect(locked.locked).toBeTruthy();
+
+    const patchResp = await request.patch(`/sales/${lockedSale.id}`, {
+      headers: { ...promoterHeaders, "If-Match": String(locked.version) },
+      data: { qty: locked.qty + 1 },
+    });
+    expect(patchResp.status()).toBe(409);
+
+    const correctionResp = await request.post(`/sales/${lockedSale.id}/corrections`, {
+      headers: promoterHeaders,
+      data: {
+        delta_qty: 1,
+        delta_price: 299990,
+        reason: "Retro adjustment",
+      },
+    });
+    expect(correctionResp.status()).toBe(201);
+    corrections.push({ saleId: lockedSale.id, deltaQty: 1, deltaPrice: 299990 });
+  });
+
+  test("BI summary reflects corrections and growth", async ({ request }) => {
+    const officeUser = getUserByKey("user_office");
+    const { headers: officeHeaders } = await loginAs(request, officeUser.email);
+
+    const summaryResp = await request.get(`/analytics/sales/summary?as_of=${formatDate(demoReferenceDate)}`, {
+      headers: officeHeaders,
+    });
+    expect(summaryResp.ok()).toBeTruthy();
+    const summary = await summaryResp.json();
+
+    const expected = computeExpected(demoReferenceDate);
+
+    expect(toNumber(summary.mtd.base_qty)).toBe(expected.mtd.baseQty);
+    expect(toNumber(summary.mtd.correction_qty)).toBe(expected.mtd.correctionQty);
+    expect(toNumber(summary.mtd.fact_qty)).toBe(expected.mtd.factQty);
+    expect(toNumber(summary.mtd.base_revenue)).toBe(expected.mtd.baseRevenue);
+    expect(toNumber(summary.mtd.correction_revenue)).toBe(expected.mtd.correctionRevenue);
+    expect(toNumber(summary.mtd.fact_revenue)).toBe(expected.mtd.factRevenue);
+
+    expectChange(summary.mtd_lfl.change_pct, expected.mtdLfl.changePct);
+    expectChange(summary.wow.change_pct, expected.wow.changePct);
+    expectChange(summary.mom.change_pct, expected.mom.changePct);
+    expectChange(summary.yoy.change_pct, expected.yoy.changePct);
+
+    expect(toNumber(summary.mtd_lfl.current.qty)).toBe(expected.mtdLfl.current.factQty);
+    expect(toNumber(summary.mtd_lfl.previous.qty)).toBe(expected.mtdLfl.previous.factQty);
+    expect(toNumber(summary.mtd_lfl.current.revenue)).toBe(expected.mtdLfl.current.factRevenue);
+    expect(toNumber(summary.mtd_lfl.previous.revenue)).toBe(expected.mtdLfl.previous.factRevenue);
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "types": ["node", "@playwright/test"],
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/ops/demo/demo_data.json
+++ b/ops/demo/demo_data.json
@@ -1,0 +1,341 @@
+{
+  "reference_date": "2024-09-15",
+  "password": "DemoPass123!",
+  "regions": [
+    {
+      "key": "region_almaty",
+      "id": "11111111-1111-1111-1111-111111111111",
+      "name": "Алматинский регион",
+      "cities": [
+        {
+          "key": "city_almaty",
+          "id": "11111111-1111-1111-1111-111111111112",
+          "name": "Алматы"
+        },
+        {
+          "key": "city_talgar",
+          "id": "11111111-1111-1111-1111-111111111113",
+          "name": "Талгар"
+        }
+      ]
+    },
+    {
+      "key": "region_astana",
+      "id": "22222222-2222-2222-2222-222222222221",
+      "name": "Астана",
+      "cities": [
+        {
+          "key": "city_astana",
+          "id": "22222222-2222-2222-2222-222222222222",
+          "name": "Астана"
+        }
+      ]
+    }
+  ],
+  "networks": [
+    {
+      "key": "network_technodom",
+      "id": "33333333-3333-3333-3333-333333333331",
+      "name": "Technodom",
+      "stores": [
+        {
+          "key": "store_technodom_mega",
+          "id": "44444444-4444-4444-4444-444444444441",
+          "code": "TD-ALM-001",
+          "name": "Technodom Mega Center",
+          "region_key": "region_almaty",
+          "city_key": "city_almaty",
+          "address": "пр. Абая 247/8"
+        },
+        {
+          "key": "store_technodom_khan",
+          "id": "44444444-4444-4444-4444-444444444442",
+          "code": "TD-AST-001",
+          "name": "Technodom Khan Shatyr",
+          "region_key": "region_astana",
+          "city_key": "city_astana",
+          "address": "пр. Кабанбай батыра 62"
+        }
+      ]
+    },
+    {
+      "key": "network_sulpak",
+      "id": "33333333-3333-3333-3333-333333333332",
+      "name": "Sulpak",
+      "stores": [
+        {
+          "key": "store_sulpak_dostyk",
+          "id": "44444444-4444-4444-4444-444444444443",
+          "code": "SP-ALM-010",
+          "name": "Sulpak Dostyk Plaza",
+          "region_key": "region_almaty",
+          "city_key": "city_almaty",
+          "address": "ул. Кабанбай батыра 85"
+        }
+      ]
+    }
+  ],
+  "products": [
+    {
+      "key": "product_reno11",
+      "id": "55555555-5555-5555-5555-555555555551",
+      "sku": "OPPO-RENO11",
+      "name": "OPPO Reno11 5G",
+      "status": "active",
+      "price": 299990,
+      "attrs": {
+        "memory": "12/256",
+        "color": "Green"
+      },
+      "valid_from": { "anchor": "reference_date", "offset_days": -180 },
+      "valid_to": null
+    },
+    {
+      "key": "product_reno10",
+      "id": "55555555-5555-5555-5555-555555555552",
+      "sku": "OPPO-RENO10",
+      "name": "OPPO Reno10 5G",
+      "status": "active",
+      "price": 259990,
+      "attrs": {
+        "memory": "8/256",
+        "color": "Silver"
+      },
+      "valid_from": { "anchor": "reference_date", "offset_days": -360 },
+      "valid_to": null
+    },
+    {
+      "key": "product_a98",
+      "id": "55555555-5555-5555-5555-555555555553",
+      "sku": "OPPO-A98",
+      "name": "OPPO A98",
+      "status": "active",
+      "price": 199990,
+      "attrs": {
+        "memory": "8/256",
+        "color": "Black"
+      },
+      "valid_from": { "anchor": "reference_date", "offset_days": -120 },
+      "valid_to": null
+    }
+  ],
+  "users": [
+    {
+      "key": "user_admin",
+      "id": "66666666-6666-6666-6666-666666666661",
+      "email": "admin@oppo.kz",
+      "full_name": "Супер Админ",
+      "role": "admin",
+      "region_key": null
+    },
+    {
+      "key": "user_office",
+      "id": "66666666-6666-6666-6666-666666666662",
+      "email": "office@oppo.kz",
+      "full_name": "Офис OPPO",
+      "role": "office",
+      "region_key": null
+    },
+    {
+      "key": "user_supervisor_almaty",
+      "id": "66666666-6666-6666-6666-666666666663",
+      "email": "supervisor.almaty@oppo.kz",
+      "full_name": "Супервизор Алматы",
+      "role": "supervisor",
+      "region_key": "region_almaty"
+    },
+    {
+      "key": "user_promoter_aidos",
+      "id": "66666666-6666-6666-6666-666666666664",
+      "email": "aidos@oppo.kz",
+      "full_name": "Айдос Каирбеков",
+      "role": "promoter",
+      "region_key": "region_almaty"
+    },
+    {
+      "key": "user_promoter_assel",
+      "id": "66666666-6666-6666-6666-666666666665",
+      "email": "assel@oppo.kz",
+      "full_name": "Асель Жумабаева",
+      "role": "promoter",
+      "region_key": "region_almaty"
+    }
+  ],
+  "bonus_schemes": [
+    {
+      "key": "scheme_technodom_2024q2",
+      "id": "77777777-7777-7777-7777-777777777771",
+      "network_key": "network_technodom",
+      "valid_from": { "anchor": "previous_month_start", "offset_days": 0 },
+      "valid_to": null,
+      "status": "published",
+      "rules": [
+        {
+          "selector_type": "series",
+          "selector_value": "Reno",
+          "amount": 15000
+        },
+        {
+          "selector_type": "sku",
+          "selector_value": "OPPO-A98",
+          "amount": 10000
+        }
+      ]
+    }
+  ],
+  "plans": [
+    {
+      "key": "plan_aidos_current",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_technodom_mega",
+      "period_offset_months": 0,
+      "target_units": 40,
+      "target_revenue": 8000000
+    },
+    {
+      "key": "plan_assel_current",
+      "promoter_key": "user_promoter_assel",
+      "store_key": "store_sulpak_dostyk",
+      "period_offset_months": 0,
+      "target_units": 25,
+      "target_revenue": 4500000
+    }
+  ],
+  "sales": [
+    {
+      "key": "sale_open_current",
+      "id": "88888888-8888-8888-8888-888888888881",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_technodom_mega",
+      "sku_key": "product_reno11",
+      "qty": 3,
+      "price": 299990,
+      "date": { "anchor": "current_month_start", "offset_days": 4 },
+      "locked": false,
+      "tags": ["mtd", "supervisor_edit", "week_minus_1"]
+    },
+    {
+      "key": "sale_week_minus1",
+      "id": "88888888-8888-8888-8888-888888888882",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_technodom_mega",
+      "sku_key": "product_a98",
+      "qty": 4,
+      "price": 199990,
+      "date": { "anchor": "last_week_start", "offset_days": 2 },
+      "locked": false,
+      "tags": ["week_minus_1"]
+    },
+    {
+      "key": "sale_week_minus2",
+      "id": "88888888-8888-8888-8888-888888888883",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_sulpak_dostyk",
+      "sku_key": "product_a98",
+      "qty": 2,
+      "price": 209990,
+      "date": { "anchor": "two_weeks_ago_start", "offset_days": 3 },
+      "locked": false,
+      "tags": ["week_minus_2"]
+    },
+    {
+      "key": "sale_previous_month_locked",
+      "id": "88888888-8888-8888-8888-888888888884",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_technodom_mega",
+      "sku_key": "product_reno10",
+      "qty": 5,
+      "price": 259990,
+      "date": { "anchor": "previous_month_start", "offset_days": 6 },
+      "locked": false,
+      "tags": ["previous_month"]
+    },
+    {
+      "key": "sale_previous_month_reference",
+      "id": "88888888-8888-8888-8888-888888888885",
+      "promoter_key": "user_promoter_assel",
+      "store_key": "store_sulpak_dostyk",
+      "sku_key": "product_reno11",
+      "qty": 3,
+      "price": 299990,
+      "date": { "anchor": "previous_month_start", "offset_days": 12 },
+      "locked": false,
+      "tags": ["previous_month", "promoter_lock_target"]
+    },
+    {
+      "key": "sale_two_months_ago",
+      "id": "88888888-8888-8888-8888-888888888886",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_technodom_mega",
+      "sku_key": "product_reno11",
+      "qty": 6,
+      "price": 289990,
+      "date": { "anchor": "two_months_ago_start", "offset_days": 9 },
+      "locked": false,
+      "tags": ["two_months_ago"]
+    },
+    {
+      "key": "sale_yoy_prev_month_store1",
+      "id": "88888888-8888-8888-8888-888888888887",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_technodom_mega",
+      "sku_key": "product_reno11",
+      "qty": 4,
+      "price": 249990,
+      "date": { "anchor": "previous_month_start_last_year", "offset_days": 6 },
+      "locked": true,
+      "tags": ["yoy_prev_year"]
+    },
+    {
+      "key": "sale_yoy_prev_month_store2",
+      "id": "88888888-8888-8888-8888-888888888888",
+      "promoter_key": "user_promoter_assel",
+      "store_key": "store_sulpak_dostyk",
+      "sku_key": "product_a98",
+      "qty": 3,
+      "price": 199990,
+      "date": { "anchor": "previous_month_start_last_year", "offset_days": 12 },
+      "locked": true,
+      "tags": ["yoy_prev_year"]
+    },
+    {
+      "key": "sale_lfl_last_year_store1",
+      "id": "88888888-8888-8888-8888-888888888889",
+      "promoter_key": "user_promoter_aidos",
+      "store_key": "store_technodom_mega",
+      "sku_key": "product_reno11",
+      "qty": 2,
+      "price": 279990,
+      "date": { "anchor": "current_month_start_last_year", "offset_days": 4 },
+      "locked": true,
+      "tags": ["lfl_last_year"]
+    },
+    {
+      "key": "sale_lfl_last_year_store2",
+      "id": "88888888-8888-8888-8888-888888888890",
+      "promoter_key": "user_promoter_assel",
+      "store_key": "store_sulpak_dostyk",
+      "sku_key": "product_a98",
+      "qty": 1,
+      "price": 199990,
+      "date": { "anchor": "current_month_start_last_year", "offset_days": 10 },
+      "locked": true,
+      "tags": ["lfl_last_year"]
+    }
+  ],
+  "closed_periods": [],
+  "inventory": [
+    {
+      "store_key_numeric": 101,
+      "sku_key_numeric": 2001,
+      "on_hand": 25,
+      "in_transit": 4
+    },
+    {
+      "store_key_numeric": 102,
+      "sku_key_numeric": 2002,
+      "on_hand": 18,
+      "in_transit": 2
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "scripts": {
     "postinstall": "npm --prefix frontend install --include=dev --no-audit --no-fund",
     "dev": "npm --prefix frontend run dev",
-    "build": "npm --prefix frontend run build"
+    "build": "npm --prefix frontend run build",
+    "test:e2e": "npx playwright test --config e2e/playwright.config.ts"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.2",
+    "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
## Motivation
- provide deterministic demo dataset to accelerate manual QA and BI validation
- cover key admin/office/supervisor/promoter/bi flows end-to-end

## Changes
- add reusable JSON demo payload and idempotent seeding script covering regions, stores, users, plans, sales, bonus schemes, and optional inventory
- expose admin APIs for products and bonus schemes plus BI summary endpoint with MTD/LFL/WoW/MoM/YoY metrics and corrections support
- extend sales corrections permissions for locked periods and document new workflows
- add Playwright suite with global reseed setup executing primary role scenarios
- document seed usage and e2e execution in README, add npm script for CI execution

## Migrations
- none (data-only seed script)

## Deployment
- run `PYTHONPATH=backend python backend/scripts/seed_demo_data.py --purge` to refresh demo data before showcasing
- ensure `npm install` at repo root to pull Playwright dependencies if CI pipeline will execute e2e suite

## Checklist
- [x] Tests pass or documented failures
- [x] Docs updated
- [x] Ready for review

------
https://chatgpt.com/codex/tasks/task_e_68e28b3623e8832f87ebf91eef2e922c